### PR TITLE
README updates for v2.0.4, removing v1 instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,854 +1,86 @@
 ![Travis Build Status](https://travis-ci.org/ripple/rippled-historical-database.svg?branch=develop)
 
-rippled Historical Database
-==========================
+Ripple Data API v2
+==================
 
-The `rippled` Historical Database provides access to raw Ripple transactions that are stored in a database. This provides an alternative to querying `rippled` itself for transactions that occurred in older ledgers, so that the `rippled` server can maintain fewer historical ledger versions and use fewer server resources.
+The Ripple Data API v2 provides access to information about changes in the Ripple Consensus Ledger, including transaction history and processed analytical data. This information is stored in a database for easy access, which frees `rippled` servers to maintain fewer historical ledger versions. Additionally, the Data API v2 acts as data source for applications such as [Ripple Charts](https://www.ripplecharts.com/) and [ripple.com](https://www.ripple.com).
 
-Ripple Labs provides a live instance of the `rippled` Historical Database API with as complete a transaction record as possible at the following address:
+Ripple provides a live instance of the Data API with as complete a transaction record as possible at the following address:
 
-`history.ripple.com`
-
-You can also [install and run your own instance of the Historical Database](#running-the-historical-database).
+[**https://data.ripple.com**](https://data.ripple.com)
 
 
-## API Methods ##
+## More Information ##
+The Ripple Data API v2 replaces the [Historical Database v1](https://ripple.com/build/historical-database/) and the [Charts API](https://ripple.com/build/charts-api/).
 
-The `rippled` Historical Database provides a REST API, with the following methods:
+* [API Methods](#api-method-reference)
+* [API Conventions](#api-conventions)
+* [Setup (local instance)](#running-the-historical-database)
+* [Release Notes](https://github.com/ripple/rippled-historical-database/releases)
 
-V1 Methods:
-* [Get Account Transaction History - `GET /v1/accounts/{:address}/transactions`](#get-account-transaction-history)
-* [Get Transaction By Account and Sequence - `GET /v1/accounts/{:address}/transactions/{:sequence}`](#get-transaction-by-account-and-sequence)
-* [Get Ledger - `GET /v1/ledgers/{:ledger_identifier}`](#get-ledger)
-* [Get Transaction - `GET /v1/transactions/{:hash}`](#get-transaction)
+[v2.0.4]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.0.4
 
-V2 Methods:
-* [Get Ledger - `GET /v2/ledgers/{:ledger_identifier}`](#get-ledger-v2)
-* [Get Transaction - `GET /v2/transactions/{:hash}`](#get-transaction-v2)
+
+# API Method Reference #
+
+The Data API v2 provides a REST API with the following methods:
+
+General Methods:
+
+* [Get Ledger - `GET /v2/ledgers/{:ledger_identifier}`](#get-ledger)
+* [Get Transaction - `GET /v2/transactions/{:hash}`](#get-transaction)
 * [Get Transactions - `GET /v2/transactions/`](#get-transactions)
-* [Get Payments - `GET /v2/payments/:currency`](#get-payments)
-* [Get Exchanges - `GET /v2/exchanges/:base/:counter`](#get-exchanges)
-* [Get Exchange Rates - `GET /v2/exchange_rates/:base/:counter`](#get-exchange-rates)
-* [Get Normalization - `GET /v2/normalize`](#normalize)
-* [Get Reports - `GET /v2/reports/`](#get-reports)
+* [Get Payments - `GET /v2/payments/{:currency}`](#get-payments)
+* [Get Exchanges - `GET /v2/exchanges/{:base}/{:counter}`](#get-exchanges)
+* [Get Exchange Rates - `GET /v2/exchange_rates/{:base}/{:counter}`](#get-exchange-rates)
+* [Normalize - `GET /v2/normalize`](#normalize)
+* [Get Daily Reports - `GET /v2/reports/`](#get-daily-reports)
 * [Get Stats - `GET /v2/stats/`](#get-stats)
-* [Get Capitalization - `GET /v2/capitalization/:currency/:issuer`](#get-capitalization)
-* [Get Active Accounts - `GET /v2/active_accounts/:base/:counter`](#get-active-accounts)
+* [Get Capitalization - `GET /v2/capitalization/{:currency}`](#get-capitalization)
+* [Get Active Accounts - `GET /v2/active_accounts/{:base}/{:counter}`](#get-active-accounts)
 * [Get Exchange Volume - `GET /v2/network/exchange_volume`](#get-exchange-volume)
 * [Get Payment Volume - `GET /v2/network/payment_volume`](#get-payment-volume)
 * [Get Issued Value - `GET /v2/network/issued_value`](#get-issued-value)
-* [Get Accounts - `GET /v2/accounts`](#get-accounts)
+* [Get All Gateways - `GET /v2/gateways`](#get-all-gateways)
+* [Get Gateway - `GET /v2/gateways/{:gateway}`](#get-gateway)
+* [Get Currency Image - `GET /v2/currencies/{:currencyimage}`](#get-currency-image)
 
-V2 Account Methods:
+Account Methods:
+
 * [Get Account - `GET /v2/accounts/{:address}`](#get-account)
+* [Get Accounts - `GET /v2/accounts`](#get-accounts)
 * [Get Account Balances - `GET /v2/accounts/{:address}/balances`](#get-account-balances)
 * [Get Account Orders - `GET /v2/accounts/{:address}/orders`](#get-account-orders)
-* [Get Account Transaction History - `GET /v2/accounts/{:address}/transactions`](#get-account-transaction-history-v2)
-* [Get Transaction By Account and Sequence - `GET /v2/accounts/{:address}/transactions/{:sequence}`](#get-transaction-by-account-and-sequence-v2)
+* [Get Account Transaction History - `GET /v2/accounts/{:address}/transactions`](#get-account-transaction-history)
+* [Get Transaction By Account and Sequence - `GET /v2/accounts/{:address}/transactions/{:sequence}`](#get-transaction-by-account-and-sequence)
 * [Get Account Payments - `GET /v2/accounts/{:address}/payments`](#get-account-payments)
 * [Get Account Exchanges - `GET /v2/accounts/{:address}/exchanges`](#get-account-exchanges)
 * [Get Account Balance Changes - `GET /v2/accounts/{:address}/balance_changes`](#get-account-balance-changes)
 * [Get Account Reports - `GET /v2/accounts/{:address}/reports`](#get-account-reports)
 
-# API Objects #
-
-## Transaction Objects ##
-
-Transactions have two formats - a compact "binary" format where the defining fields of the transaction are encoded as strings of hex, and an expanded format where the defining fields of the transaction are nested as complete JSON objects.
-
-### Full JSON Format ###
-
-| Field | Value | Description |
-|-------|-------|-------------|
-| hash  | String - Transaction Hash | An identifying SHA-512 hash unique to this transaction, as a hex string. |
-| date  | String - IS0 8601 UTC Timestamp | The time when this transaction was included in a validated ledger. |
-| ledger_index | Number - Ledger Index | The sequence number of the ledger that included this ledger. |
-| tx    | Object | The fields of this transaction object, as defined by the [Transaction Format](https://ripple.com/build/transactions) |
-| meta  | Object | Metadata about the results of this transaction. |
-
-### Binary Format ###
-
-| Field | Value | Description |
-|-------|-------|-------------|
-| hash  | String - Transaction Hash | An identifying SHA-512 hash unique to this transaction, as a hex string. |
-| date  | String - IS0 8601 UTC Timestamp | The time when this transaction was included in a validated ledger. |
-| ledger_index | Number - Ledger Index | The sequence number of the ledger that included this ledger. |
-| tx    | String | The binary data that represents this transaction, as a hex string. |
-| meta  | Object | The binary data that represents this transaction's metadata, as a hex string. |
-
-## Ledger Objects ##
-
-A "ledger" is one block of the shared global ledger. Each ledger object has the following fields:
-
-| Field        | Value | Description |
-|--------------|-------|-------------|
-| ledger_hash  | String - Transaction Hash | An identifying hash unique to this ledger, as a hex string. |
-| ledger_index | Number (Unsigned Integer) - Ledger Index | The sequence number of the ledger. Each new ledger has a ledger index 1 higher than the ledger that came before it. |
-| parent_hash  | String - Transaction Hash | The identifying hash of the previous ledger. |
-| total_coins  | Unsigned Integer | The total number of drops of XRP still in existence at the time of the ledger. (Each "drop" is 100,000 XRP.) |
-| close\_time\_res | Number | Approximate number of seconds between closing one ledger version and closing the next one. |
-| accounts\_hash | String - Hash | Hash of the account information contained in this ledger, as hex. |
-| transactions\_hash | String - Hash | Hash of the transaction information contained in this ledger, as hex. |
-| close_time | Unsigned Integer - UNIX time | The time at which this ledger was closed. |
-| close\_time\_human | String - IS0 8601 UTC Timestamp | The time at which this ledger was closed. |
-
-
-
-# API Reference #
-
-## Get Account Transaction History ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/8dc88fc5a9de5f6bd12dd3589b586872fe283ad3/api/routes/accountTx.js "Source")
-
-Retrieve a history of transactions that affected a specific account. This includes all transactions the account sent, payments the account received, and payments that rippled through the account.
-
-#### Request Format ####
-
-<!-- <div class='multicode'> -->
-
-*REST*
-
-```
-GET /v1/accounts/{:address}/transactions
-```
-
-<!-- </div> -->
-
-The following URL parameters are required by this API endpoint:
-
-| Field | Value | Description |
-|-------|-------|-------------|
-| address | String | The Ripple address of the account |
-
-Optionally, you can also include the following query parameters:
-
-| Field | Value | Description |
-|-------|-------|-------------|
-| type  | Single transaction type or comma-separated list of types | Filter results to include only transactions with the specified transaction type or types. Valid types include `OfferCreate`, `OfferCancel`, `Payment`, `TrustSet`, `AccountSet`, and `TicketCreate`. |
-| result | Transaction result code | Filter results to only transactions with the specified transaction result code. Valid result codes include `tesSUCCESS` and all [tec codes](https://ripple.com/build/transactions#tec-codes). |
-| start | ISO 8601 UTC timestamp (YYYY-MM-DDThh:mmZ) | Only retrieve transactions occurring on or after the specified date and time. |
-| end   | ISO 8601 UTC timestamp (YYYY-MM-DDThh:mmZ) | Only retrieve transactions occurring on or before the specified date and time. |
-| ledger_min | Integer | Sequence number of the earliest ledger to search. |
-| ledger_max | Integer | Sequence number of the most recent ledger to search. |
-| limit | Integer | Number of transactions to return. Defaults to 20. |
-| offset | Integer | Start getting results after skipping this many. Used for paginating results. |
-| descending | Boolean | Whether to order transactions with the most recent first. Defaults to true. |
-| binary | Boolean | If true, retrieve transactions as hex-formatted binary blobs instead of parsed JSON objects. Defaults to false. |
-
-#### Response Format ####
-
-A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
-
-| Field  | Value | Description |
-|--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
-| count  | Integer | The number of objects contained in the `transactions` field. |
-| transactions | Array of [transaction objects](#transaction-objects) | All transactions matching the request. |
-
-
-#### Example ####
-
-Request:
-
-```
-GET /v1/accounts/r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59/transactions?limit=2&type=OfferCreate
-```
-
-Response:
-
-```js
-200 OK
-{
-    "result": "success",
-    "count": 2,
-    "transactions": [
-        {
-            "tx": {
-                "TransactionType": "OfferCreate",
-                "Flags": 131072,
-                "Sequence": 159244,
-                "TakerPays": {
-                    "value": "0.001567373",
-                    "currency": "BTC",
-                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                },
-                "TakerGets": "146348921",
-                "Fee": "64",
-                "SigningPubKey": "02279DDA900BC53575FC5DFA217113A5B21C1ACB2BB2AEFDD60EA478A074E9E264",
-                "TxnSignature": "3045022100D81FFECC36A3DEF0922EB5D16F1AA5AA0804C30A18ED3B512093A75E87C81AD602206B221E22A4E3158785C109E7508624AD3DE5C0E06108D34FA709FCC9575C9441",
-                "Account": "r2d2iZiCcJmNL6vhUGFjs8U8BuUq6BnmT",
-                "hash": "03EDF724397D2DEE70E49D512AECD619E9EA536BE6CFD48ED167AE2596055C9A",
-                "ledger_index": 8317037,
-                "executed_time": 1408047740,
-                "date": 461362940
-            },
-            "meta": {
-                "TransactionIndex": 0,
-                "AffectedNodes": [
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "AccountRoot",
-                            "PreviousTxnLgrSeq": 8317036,
-                            "PreviousTxnID": "A56793D47925BED682BFF754806121E3C0281E63C24B62ADF7078EF86CC2AA53",
-                            "LedgerIndex": "2880A9B4FB90A306B576C2D532BFE390AB3904642647DCF739492AA244EF46D1",
-                            "PreviousFields": {
-                                "Balance": "275716601760"
-                            },
-                            "FinalFields": {
-                                "Flags": 0,
-                                "Sequence": 326323,
-                                "OwnerCount": 27,
-                                "Balance": "275862935331",
-                                "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw",
-                                "RegularKey": "rfYqosNivHQFJ6KpArouxoci3QE3huKNYe"
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "AccountRoot",
-                            "PreviousTxnLgrSeq": 8317030,
-                            "PreviousTxnID": "F8E33A40A481F037BA788231421737AF2AD13161928B15A14F6ABC5007D6A2B7",
-                            "LedgerIndex": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
-                            "PreviousFields": {
-                                "OwnerCount": 18,
-                                "Balance": "213169802117"
-                            },
-                            "FinalFields": {
-                                "Flags": 0,
-                                "Sequence": 1405,
-                                "OwnerCount": 17,
-                                "Balance": "213169802799",
-                                "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "Offer",
-                            "PreviousTxnLgrSeq": 8317036,
-                            "PreviousTxnID": "B7256723E74A38A17C9F4F5CB938BD45581C57767E44BF26DAC8BA9FF2D58021",
-                            "LedgerIndex": "55D0954D7C190006BF905D3B3D269A07016CB9F97B1E37ABE7CC8275DBBDE3DA",
-                            "PreviousFields": {
-                                "TakerPays": "8016312417",
-                                "TakerGets": {
-                                    "value": "0.085862",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                }
-                            },
-                            "FinalFields": {
-                                "Flags": 0,
-                                "Sequence": 326320,
-                                "Expiration": 461364125,
-                                "BookNode": "0",
-                                "OwnerNode": "3",
-                                "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F212B4AE944DDE4",
-                                "TakerPays": "7869978846",
-                                "TakerGets": {
-                                    "value": "0.084294634308",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                },
-                                "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw"
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "RippleState",
-                            "PreviousTxnLgrSeq": 8317014,
-                            "PreviousTxnID": "AB356934159ECD02D27089C0AA97EF2B3DA4B3A5A3A9EC522474CADDF276B307",
-                            "LedgerIndex": "5DC222A1BAF75AE489F9C78F772AEF6AF00C66660B4C28D93DC05FF4A4124D27",
-                            "PreviousFields": {
-                                "Balance": {
-                                    "value": "-2.254933867206176",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                }
-                            },
-                            "FinalFields": {
-                                "Flags": 2228224,
-                                "LowNode": "221",
-                                "HighNode": "0",
-                                "Balance": {
-                                    "value": "-2.253363366782792",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                },
-                                "LowLimit": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                },
-                                "HighLimit": {
-                                    "value": "1000",
-                                    "currency": "BTC",
-                                    "issuer": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "RippleState",
-                            "PreviousTxnLgrSeq": 8317030,
-                            "PreviousTxnID": "F8E33A40A481F037BA788231421737AF2AD13161928B15A14F6ABC5007D6A2B7",
-                            "LedgerIndex": "767C12AF647CDF5FEB9019B37018748A79C50EDAF87E8D4C7F39F78AA7CA9765",
-                            "PreviousFields": {
-                                "Balance": {
-                                    "value": "-0.000000007322616",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                }
-                            },
-                            "FinalFields": {
-                                "Flags": 131072,
-                                "LowNode": "43",
-                                "HighNode": "0",
-                                "Balance": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                },
-                                "LowLimit": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                },
-                                "HighLimit": {
-                                    "value": "3",
-                                    "currency": "BTC",
-                                    "issuer": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "DeletedNode": {
-                            "LedgerEntryType": "DirectoryNode",
-                            "LedgerIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F211CEE1E0697A0",
-                            "FinalFields": {
-                                "Flags": 0,
-                                "ExchangeRate": "5F211CEE1E0697A0",
-                                "RootIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F211CEE1E0697A0",
-                                "TakerPaysCurrency": "0000000000000000000000000000000000000000",
-                                "TakerPaysIssuer": "0000000000000000000000000000000000000000",
-                                "TakerGetsCurrency": "0000000000000000000000004254430000000000",
-                                "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
-                            }
-                        }
-                    },
-                    {
-                        "DeletedNode": {
-                            "LedgerEntryType": "Offer",
-                            "LedgerIndex": "AF3C702057C9C47DB9E809FD8C76CD22521012C5CC7AE95D914EC9E226F1D7E5",
-                            "PreviousFields": {
-                                "TakerPays": "182677152",
-                                "TakerGets": {
-                                    "value": "0.001959953669835",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                }
-                            },
-                            "FinalFields": {
-                                "Flags": 131072,
-                                "Sequence": 1404,
-                                "PreviousTxnLgrSeq": 8317030,
-                                "BookNode": "0",
-                                "OwnerNode": "0",
-                                "PreviousTxnID": "F8E33A40A481F037BA788231421737AF2AD13161928B15A14F6ABC5007D6A2B7",
-                                "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F211CEE1E0697A0",
-                                "TakerPays": "182676470",
-                                "TakerGets": {
-                                    "value": "0.001959946361835",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                },
-                                "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "AccountRoot",
-                            "PreviousTxnLgrSeq": 8317036,
-                            "PreviousTxnID": "049D5872010AE9144F8FE6A8A92937B6A21C065C2FA9A0233C9CAB7F5485ADC5",
-                            "LedgerIndex": "B4C12A5134DCFE012CCC035F62D5903179DE5CABE74B228D84C7E4905BECC032",
-                            "PreviousFields": {
-                                "Sequence": 159244,
-                                "Balance": "201007563226"
-                            },
-                            "FinalFields": {
-                                "Flags": 0,
-                                "Sequence": 159245,
-                                "OwnerCount": 19,
-                                "Balance": "200861228909",
-                                "Account": "r2d2iZiCcJmNL6vhUGFjs8U8BuUq6BnmT"
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "RippleState",
-                            "PreviousTxnLgrSeq": 8317036,
-                            "PreviousTxnID": "03229A664FF41A8767818DC8B236E59279078BB33C440996CB0A0093F213C173",
-                            "LedgerIndex": "F16445094C00CD3A38CE7851BD6ECA77CA2F281019BE800AB984CDF57D2F2631",
-                            "PreviousFields": {
-                                "Balance": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                }
-                            },
-                            "FinalFields": {
-                                "Flags": 1114112,
-                                "LowNode": "0",
-                                "HighNode": "233",
-                                "Balance": {
-                                    "value": "0.001567373",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                },
-                                "LowLimit": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "r2d2iZiCcJmNL6vhUGFjs8U8BuUq6BnmT"
-                                },
-                                "HighLimit": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "DirectoryNode",
-                            "LedgerIndex": "F60ADF645E78B69857D2E4AEC8B7742FEABC8431BD8611D099B428C3E816DF93",
-                            "FinalFields": {
-                                "Flags": 0,
-                                "RootIndex": "F60ADF645E78B69857D2E4AEC8B7742FEABC8431BD8611D099B428C3E816DF93",
-                                "Owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                            }
-                        }
-                    }
-                ],
-                "TransactionResult": "tesSUCCESS"
-            }
-        },
-        {
-            "tx": {
-                "TransactionType": "OfferCreate",
-                "Flags": 0,
-                "Sequence": 236535,
-                "LastLedgerSequence": 8317038,
-                "TakerPays": {
-                    "value": "0.39545282",
-                    "currency": "BTC",
-                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                },
-                "TakerGets": "36865488056",
-                "Fee": "20",
-                "SigningPubKey": "0382A086DB113581E08E439546156D7F34B68F11D70914B65F63A98A36AF9845DC",
-                "TxnSignature": "3045022100AB584255CDA4500BD82B5EA7CBB5ABB706DF657976F79187985209DDEB05C6290220365B67073797D3D4265B6E28ACC7DB7CE4EF3DF9DDB9B62ABE8078F0BF039414",
-                "Account": "rJnZ4YHCUsHvQu7R6mZohevKJDHFzVD6Zr",
-                "hash": "F8E33A40A481F037BA788231421737AF2AD13161928B15A14F6ABC5007D6A2B7",
-                "ledger_index": 8317030,
-                "executed_time": 1408047700,
-                "date": 461362900
-            },
-            "meta": {
-                "TransactionIndex": 7,
-                "AffectedNodes": [
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "AccountRoot",
-                            "PreviousTxnLgrSeq": 8317030,
-                            "PreviousTxnID": "F49ED1ACC968759EF5DA9745B08A4E47D5EA44E614AE61EE1B3CED50E1218C17",
-                            "LedgerIndex": "2B9A35D51B6BABE4F386AA3C36866BDE72E14BFC917A95C6B81F5B079F1656A3",
-                            "PreviousFields": {
-                                "Sequence": 236535,
-                                "Balance": "1035793050836"
-                            },
-                            "FinalFields": {
-                                "Flags": 0,
-                                "Sequence": 236536,
-                                "OwnerCount": 30,
-                                "Balance": "998934936914",
-                                "Account": "rJnZ4YHCUsHvQu7R6mZohevKJDHFzVD6Zr"
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "AccountRoot",
-                            "PreviousTxnLgrSeq": 8317027,
-                            "PreviousTxnID": "D92EBF936C4DEB2B99B7194C98F78A42B998E0B2C357400F139A3DA717AF8737",
-                            "LedgerIndex": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
-                            "PreviousFields": {
-                                "Balance": "176311688215"
-                            },
-                            "FinalFields": {
-                                "Flags": 0,
-                                "Sequence": 1405,
-                                "OwnerCount": 18,
-                                "Balance": "213169802117",
-                                "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "RippleState",
-                            "PreviousTxnLgrSeq": 8317027,
-                            "PreviousTxnID": "D92EBF936C4DEB2B99B7194C98F78A42B998E0B2C357400F139A3DA717AF8737",
-                            "LedgerIndex": "767C12AF647CDF5FEB9019B37018748A79C50EDAF87E8D4C7F39F78AA7CA9765",
-                            "PreviousFields": {
-                                "Balance": {
-                                    "value": "-0.396243732962616",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                }
-                            },
-                            "FinalFields": {
-                                "Flags": 131072,
-                                "LowNode": "43",
-                                "HighNode": "0",
-                                "Balance": {
-                                    "value": "-0.000000007322616",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                },
-                                "LowLimit": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                },
-                                "HighLimit": {
-                                    "value": "3",
-                                    "currency": "BTC",
-                                    "issuer": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "Offer",
-                            "PreviousTxnLgrSeq": 8317027,
-                            "PreviousTxnID": "D92EBF936C4DEB2B99B7194C98F78A42B998E0B2C357400F139A3DA717AF8737",
-                            "LedgerIndex": "AF3C702057C9C47DB9E809FD8C76CD22521012C5CC7AE95D914EC9E226F1D7E5",
-                            "PreviousFields": {
-                                "TakerPays": "37040791054",
-                                "TakerGets": {
-                                    "value": "0.397412773669835",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                }
-                            },
-                            "FinalFields": {
-                                "Flags": 131072,
-                                "Sequence": 1404,
-                                "BookNode": "0",
-                                "OwnerNode": "0",
-                                "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F211CEE1E0697A0",
-                                "TakerPays": "182677152",
-                                "TakerGets": {
-                                    "value": "0.001959953669835",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                },
-                                "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                            }
-                        }
-                    },
-                    {
-                        "ModifiedNode": {
-                            "LedgerEntryType": "RippleState",
-                            "PreviousTxnLgrSeq": 8317027,
-                            "PreviousTxnID": "D92EBF936C4DEB2B99B7194C98F78A42B998E0B2C357400F139A3DA717AF8737",
-                            "LedgerIndex": "CA152527E0627E8BB24C80D0D7D9CC515376D4D5416437F7C3687CA506901D83",
-                            "PreviousFields": {
-                                "Balance": {
-                                    "value": "-8.454143459263425",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                }
-                            },
-                            "FinalFields": {
-                                "Flags": 2228224,
-                                "LowNode": "230",
-                                "HighNode": "0",
-                                "Balance": {
-                                    "value": "-8.849596279263425",
-                                    "currency": "BTC",
-                                    "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                                },
-                                "LowLimit": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                                },
-                                "HighLimit": {
-                                    "value": "0",
-                                    "currency": "BTC",
-                                    "issuer": "rJnZ4YHCUsHvQu7R6mZohevKJDHFzVD6Zr"
-                                }
-                            }
-                        }
-                    }
-                ],
-                "TransactionResult": "tesSUCCESS"
-            }
-        }
-    ]
-}
-```
-
-## Get Transaction By Account and Sequence ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/accountTxSeq.js "Source")
-
-Retrieve a specific transaction, by account and sequence number.
-
-#### Request Format ####
-
-<!-- <div class='multicode'> -->
-
-*REST*
-
-```
-GET /v1/accounts/{:address}/transactions/{:sequence}
-```
-
-<!-- </div> -->
-
-The following URL parameters are required by this API endpoint:
-
-| Field | Value | Description |
-|-------|-------|-------------|
-| address | String | The Ripple address of the account |
-| sequence | Unsigned Integer | The [sequence number of the transaction](https://ripple.com/build/transactions#common-fields). |
-
-Optionally, you can also include the following query parameter:
-
-| Field | Value | Description |
-|-------|-------|-------------|
-| binary | Boolean | If true, retrieve the transaction as a hex-formatted binary blob instead of parsed JSON objects. Defaults to false. |
-
-#### Response Format ####
-
-A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
-
-| Field  | Value | Description |
-|--------|-------|-------------|
-| result | `success` | Indicates that the body represents a successful response. |
-| transaction | [Transaction object](#transaction-objects) | The requested transaction |
-
-
-#### Example ####
-
-Request:
-```
-GET /v1/accounts/rJnZ4YHCUsHvQu7R6mZohevKJDHFzVD6Zr/transactions/236535
-```
-
-Response:
-
-```js
-200 OK
-{
-    "result": "success",
-    "transaction": {
-        "hash": "F8E33A40A481F037BA788231421737AF2AD13161928B15A14F6ABC5007D6A2B7",
-        "ledger_index": 8317030,
-        "date": "2014-08-14T20:21:40+00:00",
-        "tx": {
-            "TransactionType": "OfferCreate",
-            "Flags": 0,
-            "Sequence": 236535,
-            "LastLedgerSequence": 8317038,
-            "TakerPays": {
-                "value": "0.39545282",
-                "currency": "BTC",
-                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-            },
-            "TakerGets": "36865488056",
-            "Fee": "20",
-            "SigningPubKey": "0382A086DB113581E08E439546156D7F34B68F11D70914B65F63A98A36AF9845DC",
-            "TxnSignature": "3045022100AB584255CDA4500BD82B5EA7CBB5ABB706DF657976F79187985209DDEB05C6290220365B67073797D3D4265B6E28ACC7DB7CE4EF3DF9DDB9B62ABE8078F0BF039414",
-            "Account": "rJnZ4YHCUsHvQu7R6mZohevKJDHFzVD6Zr"
-        },
-        "meta": {
-            "TransactionIndex": 7,
-            "AffectedNodes": [
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "AccountRoot",
-                        "PreviousTxnLgrSeq": 8317030,
-                        "PreviousTxnID": "F49ED1ACC968759EF5DA9745B08A4E47D5EA44E614AE61EE1B3CED50E1218C17",
-                        "LedgerIndex": "2B9A35D51B6BABE4F386AA3C36866BDE72E14BFC917A95C6B81F5B079F1656A3",
-                        "PreviousFields": {
-                            "Sequence": 236535,
-                            "Balance": "1035793050836"
-                        },
-                        "FinalFields": {
-                            "Flags": 0,
-                            "Sequence": 236536,
-                            "OwnerCount": 30,
-                            "Balance": "998934936914",
-                            "Account": "rJnZ4YHCUsHvQu7R6mZohevKJDHFzVD6Zr"
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "AccountRoot",
-                        "PreviousTxnLgrSeq": 8317027,
-                        "PreviousTxnID": "D92EBF936C4DEB2B99B7194C98F78A42B998E0B2C357400F139A3DA717AF8737",
-                        "LedgerIndex": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
-                        "PreviousFields": {
-                            "Balance": "176311688215"
-                        },
-                        "FinalFields": {
-                            "Flags": 0,
-                            "Sequence": 1405,
-                            "OwnerCount": 18,
-                            "Balance": "213169802117",
-                            "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "RippleState",
-                        "PreviousTxnLgrSeq": 8317027,
-                        "PreviousTxnID": "D92EBF936C4DEB2B99B7194C98F78A42B998E0B2C357400F139A3DA717AF8737",
-                        "LedgerIndex": "767C12AF647CDF5FEB9019B37018748A79C50EDAF87E8D4C7F39F78AA7CA9765",
-                        "PreviousFields": {
-                            "Balance": {
-                                "value": "-0.396243732962616",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            }
-                        },
-                        "FinalFields": {
-                            "Flags": 131072,
-                            "LowNode": "0000000000000043",
-                            "HighNode": "0000000000000000",
-                            "Balance": {
-                                "value": "-0.000000007322616",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            },
-                            "LowLimit": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            },
-                            "HighLimit": {
-                                "value": "3",
-                                "currency": "BTC",
-                                "issuer": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                            }
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "Offer",
-                        "PreviousTxnLgrSeq": 8317027,
-                        "PreviousTxnID": "D92EBF936C4DEB2B99B7194C98F78A42B998E0B2C357400F139A3DA717AF8737",
-                        "LedgerIndex": "AF3C702057C9C47DB9E809FD8C76CD22521012C5CC7AE95D914EC9E226F1D7E5",
-                        "PreviousFields": {
-                            "TakerPays": "37040791054",
-                            "TakerGets": {
-                                "value": "0.397412773669835",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            }
-                        },
-                        "FinalFields": {
-                            "Flags": 131072,
-                            "Sequence": 1404,
-                            "BookNode": "0000000000000000",
-                            "OwnerNode": "0000000000000000",
-                            "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F211CEE1E0697A0",
-                            "TakerPays": "182677152",
-                            "TakerGets": {
-                                "value": "0.001959953669835",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            },
-                            "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "RippleState",
-                        "PreviousTxnLgrSeq": 8317027,
-                        "PreviousTxnID": "D92EBF936C4DEB2B99B7194C98F78A42B998E0B2C357400F139A3DA717AF8737",
-                        "LedgerIndex": "CA152527E0627E8BB24C80D0D7D9CC515376D4D5416437F7C3687CA506901D83",
-                        "PreviousFields": {
-                            "Balance": {
-                                "value": "-8.454143459263425",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            }
-                        },
-                        "FinalFields": {
-                            "Flags": 2228224,
-                            "LowNode": "0000000000000230",
-                            "HighNode": "0000000000000000",
-                            "Balance": {
-                                "value": "-8.849596279263425",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            },
-                            "LowLimit": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            },
-                            "HighLimit": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "rJnZ4YHCUsHvQu7R6mZohevKJDHFzVD6Zr"
-                            }
-                        }
-                    }
-                }
-            ],
-            "TransactionResult": "tesSUCCESS"
-        }
-    }
-}
-```
-
 
 ## Get Ledger ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/6e4d601d18e60582754c8e0bde592d888cae5efc/api/routes/getLedger.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getLedger.js "Source")
 
-Retrieve a specific ledger version.
+Retrieve a specific Ledger by hash, index, date, or latest validated.
 
 #### Request Format ####
 
-<!-- <div class='multicode'> -->
+<!--<div class='multicode'>-->
 
 *REST*
 
 ```
-GET /v1/ledgers/{:ledger_identifier}
+GET /v2/ledgers/{:identifier}
 ```
 
-<!-- </div> -->
+<!--</div>-->
 
 The following URL parameters are required by this API endpoint:
 
 | Field | Value | Description |
 |-------|-------|-------------|
-| ledger_identifier | Ledger Hash, Sequence Number, or ISO 8601 UTC timestamp (YYYY-MM-DDThh:mmZ) | (Optional) An identifier for the ledger to retrieve: either the full hash in hex, an integer sequence number, or a date-time. If a date-time is provided, retrieve the ledger that was most recently closed at that time. If omitted, retrieve the latest validated ledger. |
+| ledger_identifier | Ledger [Hash][], [Ledger Index][], or [Timestamp][] | (Optional) An identifier for the ledger to retrieve: either the full hash in hex, an integer sequence number, or a date-time. If a date-time is provided, retrieve the ledger that was most recently closed at that time. If omitted, retrieve the latest validated ledger. |
 
 Optionally, you can also include the following query parameters:
 
@@ -872,7 +104,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 Request:
 
 ```
-GET /v1/ledgers/3170DA37CE2B7F045F889594CBC323D88686D2E90E8FFD2BBCD9BAD12E416DB5
+GET /v2/ledgers/3170DA37CE2B7F045F889594CBC323D88686D2E90E8FFD2BBCD9BAD12E416DB5
 ```
 
 Response:
@@ -896,28 +128,29 @@ Response:
 ```
 
 
+
 ## Get Transaction ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/24595d37551687aa65209369377d15a803ac8f73/api/routes/getTx.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getTransactions.js "Source")
 
 Retrieve a specific transaction by its identifying hash.
 
 #### Request Format ####
 
-<!-- <div class='multicode'> -->
+<!--<div class='multicode'>-->
 
 *REST*
 
 ```
-GET /v1/transactions/{:hash}
+GET /v2/transactions/{:hash}
 ```
 
-<!-- </div> -->
+<!--</div>-->
 
 The following URL parameters are required by this API endpoint:
 
 | Field | Value | Description |
 |-------|-------|-------------|
-| hash  | Transaction Hash | The identifying (SHA-512) hash of the transaction, as hex. |
+| hash  | String - [Hash][] | The identifying hash of the transaction. |
 
 Optionally, you can also include the following query parameters:
 
@@ -939,10 +172,10 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 Request:
 
 ```
-GET /v1/transactions/03EDF724397D2DEE70E49D512AECD619E9EA536BE6CFD48ED167AE2596055C9A
+GET /v2/transactions/03EDF724397D2DEE70E49D512AECD619E9EA536BE6CFD48ED167AE2596055C9A
 ```
 
-Response:
+Response (trimmed for size):
 
 ```js
 200 OK
@@ -989,236 +222,8 @@ Response:
                         }
                     }
                 },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "AccountRoot",
-                        "PreviousTxnLgrSeq": 8317030,
-                        "PreviousTxnID": "F8E33A40A481F037BA788231421737AF2AD13161928B15A14F6ABC5007D6A2B7",
-                        "LedgerIndex": "4F83A2CF7E70F77F79A307E6A472BFC2585B806A70833CCD1C26105BAE0D6E05",
-                        "PreviousFields": {
-                            "OwnerCount": 18,
-                            "Balance": "213169802117"
-                        },
-                        "FinalFields": {
-                            "Flags": 0,
-                            "Sequence": 1405,
-                            "OwnerCount": 17,
-                            "Balance": "213169802799",
-                            "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "Offer",
-                        "PreviousTxnLgrSeq": 8317036,
-                        "PreviousTxnID": "B7256723E74A38A17C9F4F5CB938BD45581C57767E44BF26DAC8BA9FF2D58021",
-                        "LedgerIndex": "55D0954D7C190006BF905D3B3D269A07016CB9F97B1E37ABE7CC8275DBBDE3DA",
-                        "PreviousFields": {
-                            "TakerPays": "8016312417",
-                            "TakerGets": {
-                                "value": "0.085862",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            }
-                        },
-                        "FinalFields": {
-                            "Flags": 0,
-                            "Sequence": 326320,
-                            "Expiration": 461364125,
-                            "BookNode": "0000000000000000",
-                            "OwnerNode": "0000000000000003",
-                            "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F212B4AE944DDE4",
-                            "TakerPays": "7869978846",
-                            "TakerGets": {
-                                "value": "0.084294634308",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            },
-                            "Account": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw"
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "RippleState",
-                        "PreviousTxnLgrSeq": 8317014,
-                        "PreviousTxnID": "AB356934159ECD02D27089C0AA97EF2B3DA4B3A5A3A9EC522474CADDF276B307",
-                        "LedgerIndex": "5DC222A1BAF75AE489F9C78F772AEF6AF00C66660B4C28D93DC05FF4A4124D27",
-                        "PreviousFields": {
-                            "Balance": {
-                                "value": "-2.254933867206176",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            }
-                        },
-                        "FinalFields": {
-                            "Flags": 2228224,
-                            "LowNode": "0000000000000221",
-                            "HighNode": "0000000000000000",
-                            "Balance": {
-                                "value": "-2.253363366782792",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            },
-                            "LowLimit": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            },
-                            "HighLimit": {
-                                "value": "1000",
-                                "currency": "BTC",
-                                "issuer": "rfCFLzNJYvvnoGHWQYACmJpTgkLUaugLEw"
-                            }
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "RippleState",
-                        "PreviousTxnLgrSeq": 8317030,
-                        "PreviousTxnID": "F8E33A40A481F037BA788231421737AF2AD13161928B15A14F6ABC5007D6A2B7",
-                        "LedgerIndex": "767C12AF647CDF5FEB9019B37018748A79C50EDAF87E8D4C7F39F78AA7CA9765",
-                        "PreviousFields": {
-                            "Balance": {
-                                "value": "-0.000000007322616",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            }
-                        },
-                        "FinalFields": {
-                            "Flags": 131072,
-                            "LowNode": "0000000000000043",
-                            "HighNode": "0000000000000000",
-                            "Balance": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            },
-                            "LowLimit": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            },
-                            "HighLimit": {
-                                "value": "3",
-                                "currency": "BTC",
-                                "issuer": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                            }
-                        }
-                    }
-                },
-                {
-                    "DeletedNode": {
-                        "LedgerEntryType": "DirectoryNode",
-                        "LedgerIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F211CEE1E0697A0",
-                        "FinalFields": {
-                            "Flags": 0,
-                            "ExchangeRate": "5F211CEE1E0697A0",
-                            "RootIndex": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F211CEE1E0697A0",
-                            "TakerPaysCurrency": "0000000000000000000000000000000000000000",
-                            "TakerPaysIssuer": "0000000000000000000000000000000000000000",
-                            "TakerGetsCurrency": "0000000000000000000000004254430000000000",
-                            "TakerGetsIssuer": "0A20B3C85F482532A9578DBB3950B85CA06594D1"
-                        }
-                    }
-                },
-                {
-                    "DeletedNode": {
-                        "LedgerEntryType": "Offer",
-                        "LedgerIndex": "AF3C702057C9C47DB9E809FD8C76CD22521012C5CC7AE95D914EC9E226F1D7E5",
-                        "PreviousFields": {
-                            "TakerPays": "182677152",
-                            "TakerGets": {
-                                "value": "0.001959953669835",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            }
-                        },
-                        "FinalFields": {
-                            "Flags": 131072,
-                            "Sequence": 1404,
-                            "PreviousTxnLgrSeq": 8317030,
-                            "BookNode": "0000000000000000",
-                            "OwnerNode": "0000000000000000",
-                            "PreviousTxnID": "F8E33A40A481F037BA788231421737AF2AD13161928B15A14F6ABC5007D6A2B7",
-                            "BookDirectory": "7B73A610A009249B0CC0D4311E8BA7927B5A34D86634581C5F211CEE1E0697A0",
-                            "TakerPays": "182676470",
-                            "TakerGets": {
-                                "value": "0.001959946361835",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            },
-                            "Account": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "AccountRoot",
-                        "PreviousTxnLgrSeq": 8317036,
-                        "PreviousTxnID": "049D5872010AE9144F8FE6A8A92937B6A21C065C2FA9A0233C9CAB7F5485ADC5",
-                        "LedgerIndex": "B4C12A5134DCFE012CCC035F62D5903179DE5CABE74B228D84C7E4905BECC032",
-                        "PreviousFields": {
-                            "Sequence": 159244,
-                            "Balance": "201007563226"
-                        },
-                        "FinalFields": {
-                            "Flags": 0,
-                            "Sequence": 159245,
-                            "OwnerCount": 19,
-                            "Balance": "200861228909",
-                            "Account": "r2d2iZiCcJmNL6vhUGFjs8U8BuUq6BnmT"
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "RippleState",
-                        "PreviousTxnLgrSeq": 8317036,
-                        "PreviousTxnID": "03229A664FF41A8767818DC8B236E59279078BB33C440996CB0A0093F213C173",
-                        "LedgerIndex": "F16445094C00CD3A38CE7851BD6ECA77CA2F281019BE800AB984CDF57D2F2631",
-                        "PreviousFields": {
-                            "Balance": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            }
-                        },
-                        "FinalFields": {
-                            "Flags": 1114112,
-                            "LowNode": "0000000000000000",
-                            "HighNode": "0000000000000233",
-                            "Balance": {
-                                "value": "0.001567373",
-                                "currency": "BTC",
-                                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji"
-                            },
-                            "LowLimit": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "r2d2iZiCcJmNL6vhUGFjs8U8BuUq6BnmT"
-                            },
-                            "HighLimit": {
-                                "value": "0",
-                                "currency": "BTC",
-                                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
-                            }
-                        }
-                    }
-                },
-                {
-                    "ModifiedNode": {
-                        "LedgerEntryType": "DirectoryNode",
-                        "LedgerIndex": "F60ADF645E78B69857D2E4AEC8B7742FEABC8431BD8611D099B428C3E816DF93",
-                        "FinalFields": {
-                            "Flags": 0,
-                            "RootIndex": "F60ADF645E78B69857D2E4AEC8B7742FEABC8431BD8611D099B428C3E816DF93",
-                            "Owner": "r9cZA1mLK5R5Am25ArfXFmqgNwjZgnfk59"
-                        }
-                    }
-                }
+                
+                ...
             ],
             "TransactionResult": "tesSUCCESS"
         }
@@ -1228,66 +233,37 @@ Response:
 
 
 
-## Get Ledger V2 ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getLedger.js "Source")
-
-Retrieve a specific Ledger by hash, index, date, or latest validated.
-
-```
-GET /v2/ledgers/{:identifier}
-```
-
-#### Params ####
-  * :identifier (string)...ledger hash, index, or close time.  Optional, defaults to latest close time
-  * transactions (boolean)...include transaction hashes in response
-  * binary (boolean)...include transactions in binary form
-  * expand (boolean)...include transactions in JSON
-
-#### Response Format ####
-  same as v1
 
 
-
-
-
-## Get Transaction V2 ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getTransactions.js "Source")
-
-Retrieve a specific transaction by transaction hash
-
-```
-GET /v2/transactions/{:hash}
-```
-
-#### Params ####
-  * :hash (string)...transaction hash of desired transaction
-
-
-#### Response Format ####
-A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
-  same as v1
-
-
-
-
-## Get Transactions V2 ##
+## Get Transactions ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getTransactions.js "Source")
 
 Retrieve transactions by time
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/transactions/
 ```
 
-#### Params ####
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * descending (boolean)...reverse cronological order
-  * type (string)...filter transactions for a specific transaction type
-  * result (string)...filter transactions for a specific transaction result
-  * binary (boolean)...return transactions in binary form
-  * limit (integer)...max results per page (defaults to 20)
-  * marker (string)...pagination key from previously returned response
+<!--</div>-->
+
+Optionally, you can include the following query parameters:
+
+| Field      | Value | Description |
+|------------|-------|-------------|
+| start      | String - [Timestamp][]  | Filter results to this time and later. |
+| end        | String - [Timestamp][]  | Filter results to this time and earlier. |
+| descending | Boolean | If true, return results in reverse chronological order. Defaults to false. |
+| type       | String | Filter transactions to a specific [transaction type](https://ripple.com/build/transactions/). |
+| result     | String | Filter transactions for a specific [transaction result](https://ripple.com/build/transactions/#transaction-results). |
+| binary     | Boolean | If true, return transactions in binary form. Defaults to false. |
+| limit      | Integer | Max results per page (defaults to 20). Cannot be more than 100. |
+| marker     | String | [Pagination](#pagination) marker from a previous response. |
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1296,40 +272,271 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of Transactions returned. |
-| marker | String | Pagination marker |
+| marker | String | (May be omitted) Pagination marker |
 | transactions | Array of [Transaction object](#transaction-objects) | The requested transactions |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/transactions/?result=tecPATH_DRY&limit=2&type=Payment
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 2,
+  "marker": "20130106022000|000000053869|00000",
+  "transactions": [
+    {
+      "hash": "B8E4335A94438EC8209135A4E861A4C88F988C651B819DDAF2E8C55F9B41E589",
+      "date": "2013-01-02T20:13:40+00:00",
+      "ledger_index": 40752,
+      "ledger_hash": "55A900C2BA9483DC83F8FC065DE7789570662365BDE98EB75C5F4CE4F9B43214",
+      "tx": {
+        "TransactionType": "Payment",
+        "Flags": 0,
+        "Sequence": 61,
+        "Amount": {
+          "value": "96",
+          "currency": "USD",
+          "issuer": "rJ6VE6L87yaVmdyxa9jZFXSAdEFSoTGPbE"
+        },
+        "Fee": "10",
+        "SigningPubKey": "02082622E4DA1DC6EA6B38A48956D816881E000ACF0C5F5B52863B9F698799D474",
+        "TxnSignature": "304402200A0746192EBC7BC3C1B9D657F42B6345A49D75FE23EF340CB6F0427254C139D00220446BF9169C94AEDC87F56D01DB011866E2A67E2AADDCC45C4D11422550D044CB",
+        "Account": "rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY",
+        "Destination": "rJ6VE6L87yaVmdyxa9jZFXSAdEFSoTGPbE"
+      },
+      "meta": {
+        "TransactionIndex": 0,
+        "AffectedNodes": [
+          {
+            "ModifiedNode": {
+              "LedgerEntryType": "AccountRoot",
+              "PreviousTxnLgrSeq": 40212,
+              "PreviousTxnID": "F491DC8B5E51045D4420297293199039D5AE1EA0C6D62CAD9A973E3C89E40CD6",
+              "LedgerIndex": "9B242A0D59328CE964FFFBFF7D3BBF8B024F9CB1A212923727B42F24ADC93930",
+              "PreviousFields": {
+                "Sequence": 61,
+                "Balance": "8178999999999400"
+              },
+              "FinalFields": {
+                "Flags": 0,
+                "Sequence": 62,
+                "OwnerCount": 6,
+                "Balance": "8178999999999390",
+                "Account": "rB5TihdPbKgMrkFqrqUC3yLdE8hhv4BdeY"
+              }
+            }
+          }
+        ],
+        "TransactionResult": "tecPATH_DRY"
+      }
+    },
+    {
+      "hash": "1E1C14BF5E61682F3DC9D035D9908816497B8E8843E05C0EE98E06DFDDDAE920",
+      "date": "2013-01-05T08:43:10+00:00",
+      "ledger_index": 51819,
+      "ledger_hash": "88ED10E4E31FC7580285CF173B264690B0E8688A3FC9F5F9C62F1A295B96269D",
+      "tx": {
+        "TransactionType": "Payment",
+        "Flags": 0,
+        "Sequence": 10,
+        "Amount": {
+          "value": "2",
+          "currency": "EUR",
+          "issuer": "rfitr7nL7MX85LLKJce7E3ATQjSiyUPDfj"
+        },
+        "Fee": "10",
+        "SigningPubKey": "03FDDCD97668B686100E60653FD1E5210A8310616669AACB3A1FCC6D2C090CCB32",
+        "TxnSignature": "304402204F9BB7E37C14A3A3762E2A7DADB9A28D1AFFB3797521229B6FB98BA666B5491B02204F69AAEAFAC8FA473E52042FF06035AB3618A54E0B76C9852766D55184E98598",
+        "Account": "rhdAw3LiEfWWmSrbnZG3udsN7PoWKT56Qo",
+        "Destination": "rfitr7nL7MX85LLKJce7E3ATQjSiyUPDfj"
+      },
+      "meta": {
+        "TransactionIndex": 0,
+        "AffectedNodes": [
+          {
+            "ModifiedNode": {
+              "LedgerEntryType": "AccountRoot",
+              "PreviousTxnLgrSeq": 51814,
+              "PreviousTxnID": "5EC1C179996BD87E2EB11FE60A37ADD0FB2229ADC7D13B204FAB04FABED8A38D",
+              "LedgerIndex": "AC1B67084F84839A3158A4E38618218BF9016047B1EE435AECD4B02226AB2105",
+              "PreviousFields": {
+                "Sequence": 10,
+                "Balance": "10000999910"
+              },
+              "FinalFields": {
+                "Flags": 0,
+                "Sequence": 11,
+                "OwnerCount": 2,
+                "Balance": "10000999900",
+                "Account": "rhdAw3LiEfWWmSrbnZG3udsN7PoWKT56Qo"
+              }
+            }
+          }
+        ],
+        "TransactionResult": "tecPATH_DRY"
+      }
+    }
+  ]
+}
+```
+
+
 
 ## Get Payments ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getPayments.js "Source")
 
-Retrieve Payments over time.  Payments are `Payment` type transactions excluding those with the same account as both the source and destination.  Results can be returned as individual payments or aggregated to a specific list of intervals if a currency and issuer is provided.
+Retrieve Payments over time, where Payments are defined as `Payment` type transactions where the sender of the transaction is not also the destination. _(New in [v2.0.4][])_
+
+Results can be returned as individual payments, or aggregated to a specific list of intervals if currency and issuer are provided.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST - All Currencies*
+
+```
+GET /v2/payments/
+```
+
+*REST - Specific Currency*
 
 ```
 GET /v2/payments/{:currency}
 ```
 
-#### Params ####
-  * :currency(string)...base currency of the pair in the format currency[+issuer]
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * interval (string)... aggregation interval (currency is required for aggregated results):
-    * day
-    * week
-    * month
-  * descending (boolean)...reverse cronological order
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
+
+This method accepts the following URL parameters:
+
+| Field     | Value  | Description |
+|-----------|--------|-------------|
+| :currency | String | (Optional) Currency code, followed by `+` and an issuer. (Or just `XRP`.) If omitted, return payments for all currencies. |
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| start      | String - [Timestamp][]  | Filter results to this time and later. |
+| end        | String - [Timestamp][]  | Filter results to this time and earlier. |
+| interval   | String  | If provided and `currency` is also specified, return results aggregated into intervals of the specified length instead of individual payments. Valid intervals are `day`, `week`, or `month`. |
+| descending | Boolean | Reverse chronological order. |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response. |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+
 
 #### Response Format ####
+
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
-| count | Integer | Number of Transactions returned. |
-| marker | String | Pagination marker |
-| payments | Array of payments objects | The requested payments |
+| count | Integer | Number of Transactions returned |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
+| payments | Array of [Payment Objects][], or array of aggregate objects | The requested payments |
+
+
+##### Aggregate Results #####
+
+If the request specifies a `currency` and an `interval`, the result includes objects summarizing activity over a specific time period instead of listing individual payments. Each interval summary object has the following fields:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| count | Number | The number of payments that occurred during this interval. |
+| currency | String - Currency Code | This summary describes payments that delivered the specified currency. |
+| issuer | String - Address | (Omitted for XRP) This summary describes payments that delivered the currency issued by this address. |
+| start | String - [Timestamp][] | The start time of this interval |
+| total\_amount | Number | The amount of the `currency` delivered during this interval. |
+| average\_amount | Number | The average amount of currency delivered by a single payment during this interval. |
+
+#### Example ####
+
+Request: 
+
+```
+GET /v2/payments/BTC+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q?limit=2
+```
+
+Response:
+
+```
+200 OK
+{
+  "result": "success",
+  "count": 2,
+  "marker": "20131124004240|000003504935|00002",
+  "payments": [
+    {
+      "amount": "100.0",
+      "delivered_amount": "100.0",
+      "destination_balance_changes": [
+        {
+          "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+          "currency": "BTC",
+          "value": "100"
+        }
+      ],
+      "transaction_cost": "1.0E-5",
+      "source_balance_changes": [
+        {
+          "counterparty": "rwm98fCBS8tV1YB8CGho8zUPW5J7N41th2",
+          "currency": "BTC",
+          "value": "-100"
+        }
+      ],
+      "tx_index": 3,
+      "currency": "BTC",
+      "destination": "rwm98fCBS8tV1YB8CGho8zUPW5J7N41th2",
+      "executed_time": "2013-09-27T04:03:00Z",
+      "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+      "ledger_index": 2424349,
+      "source": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+      "source_currency": "BTC",
+      "tx_hash": "EDDE2601C38F886E1183B5E7E1BFD936105C76E3648E3FAD2A6C55E90BABDB47"
+    },
+    {
+      "amount": "0.2",
+      "delivered_amount": "0.2",
+      "destination_balance_changes": [
+        {
+          "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+          "currency": "BTC",
+          "value": "0.2"
+        }
+      ],
+      "transaction_cost": "1.5E-5",
+      "max_amount": "0.202",
+      "source_balance_changes": [
+        {
+          "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+          "currency": "BTC",
+          "value": "-0.2"
+        }
+      ],
+      "tx_index": 1,
+      "currency": "BTC",
+      "destination": "rHfcNvcg8pBqBxtSvD9Ma8gF17uxauB31o",
+      "executed_time": "2013-11-20T23:52:30Z",
+      "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+      "ledger_index": 3445885,
+      "source": "rwm98fCBS8tV1YB8CGho8zUPW5J7N41th2",
+      "source_currency": "BTC",
+      "tx_hash": "F30D6CED4B0C37660F6DD741C9CA49F0BCB2D2648CDB8FC8AD6CFD86A86384E2"
+    }
+  ]
+}
+```
+
+
 
 
 
@@ -1338,33 +545,38 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 Retrieve Exchanges for a given currency pair over time.  Results can be returned as individual exchanges or aggregated to a specific list of intervals
 
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
+
 ```
 GET /v2/exchanges/{:base}/{:counter}
 ```
 
-#### Params ####
-  * :base(string)...base currency of the pair in the format currency[+issuer] (required)
-  * :counter(string)...counter currency of the pair in the format currency[+issuer] (required)
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * interval (string)...aggregation interval:
-    * 1minute
-    * 5minute
-    * 15minute
-    * 30minute
-    * 1hour
-    * 2hour
-    * 4hour
-    * 1day
-    * 3day
-    * 7day
-    * 1month
-  * descending (boolean)...reverse cronological order
-  * reduce (boolean)...aggregate all individual results
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * autobridged (boolean)...return only results from autobridged exchanges
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| base  | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+| counter | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+
+Optionally, you can also include the following query parameters:
+
+| Field       | Value | Description |
+|-------------|-------|-------------|
+| start       | String - [Timestamp][] | Filter results to this time and later. |
+| end         | String - [Timestamp][] | Filter results to this time and earlier. |
+| interval    | String | Aggregation interval: `1minute`, `5minute`, `15minute`, `30minute`, `1hour`, `2hour`, `4hour`, `1day`, `3day`, `7day`, or `1month`. Defaults to non-aggregated results. |
+| descending  | Boolean | If true, return results in reverse chronological order. |
+| reduce      | Boolean | Aggregate all individual results. Defaults to false. |
+| limit       | Integer | Maximum results per page (defaults to 200). Cannot be more than 20,000 if `reduce` is true. Otherwise cannot be more than 1,000. |
+| marker      | String | [Pagination](#pagination) key from previously returned response. |
+| autobridged | Boolean | If true, filter results to autobridged exchanges only. |
+| format      | String | Format of returned results: `csv` or `json`. Defaults to `json` |
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1373,29 +585,122 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of Transactions returned. |
-| marker | String | Pagination marker |
-| exchanges | Array of exchange objects | The requested exchanges |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
+| exchanges | Array of [Exchange Objects][] | The requested exchanges |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/exchanges/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q/XRP?descending=true&limit=3&result=tesSUCCESS&type=OfferCreate
+```
+
+Response:
+
+```
+{
+    "result": "success",
+    "count": 3,
+    "marker": "USD|rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q|XRP||20151021222220|000016612683|00017|00000",
+    "exchanges": [
+        {
+            "base_amount": 4.98954834453577,
+            "counter_amount": 1047.806201,
+            "node_index": 9,
+            "rate": 210.00021000021,
+            "tx_index": 0,
+            "buyer": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
+            "executed_time": "2015-10-21T23:09:50",
+            "ledger_index": 16613308,
+            "offer_sequence": 1010056,
+            "provider": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
+            "seller": "rK2o63evRPdRoMT2ZaW72wsHsFzcjnRLLq",
+            "taker": "rK2o63evRPdRoMT2ZaW72wsHsFzcjnRLLq",
+            "tx_hash": "25600A10E5395D45A9D514E1EC3D98C341C5451FD21C48FA9D104C310EC29D6B",
+            "tx_type": "Payment",
+            "base_currency": "USD",
+            "base_issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+            "counter_currency": "XRP"
+        },
+        {
+            "base_amount": 0.0004716155440678037,
+            "counter_amount": 0.1,
+            "node_index": 3,
+            "rate": 212.03711637126,
+            "tx_index": 0,
+            "buyer": "rfh3pFHkCXv3TgzsEJgyCzF1CduZHCLi9o",
+            "executed_time": "2015-10-21T23:09:50",
+            "ledger_index": 16613308,
+            "offer_sequence": 158081,
+            "provider": "rfh3pFHkCXv3TgzsEJgyCzF1CduZHCLi9o",
+            "seller": "rK2o63evRPdRoMT2ZaW72wsHsFzcjnRLLq",
+            "taker": "rK2o63evRPdRoMT2ZaW72wsHsFzcjnRLLq",
+            "tx_hash": "25600A10E5395D45A9D514E1EC3D98C341C5451FD21C48FA9D104C310EC29D6B",
+            "tx_type": "Payment",
+            "base_currency": "USD",
+            "base_issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+            "counter_currency": "XRP"
+        },
+        {
+            "base_amount": 0.0004714169229390923,
+            "counter_amount": 0.1,
+            "node_index": 3,
+            "rate": 212.1264535361624,
+            "tx_index": 17,
+            "autobridged_currency": "USD",
+            "autobridged_issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+            "buyer": "rfh3pFHkCXv3TgzsEJgyCzF1CduZHCLi9o",
+            "executed_time": "2015-10-21T22:22:20",
+            "ledger_index": 16612683,
+            "offer_sequence": 158059,
+            "provider": "rfh3pFHkCXv3TgzsEJgyCzF1CduZHCLi9o",
+            "seller": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
+            "taker": "rpP2JgiMyTF5jR5hLG3xHCPi1knBb1v9cM",
+            "tx_hash": "F05F670B06D641D7F6FE18E450DDB2C7A4DDF76D580C34C820939DC22AD9F582",
+            "tx_type": "OfferCreate",
+            "base_currency": "USD",
+            "base_issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+            "counter_currency": "XRP"
+        }
+    ]
+}
+```
 
 
 
 ## Get Exchange Rates ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getExchangeRate.js "Source")
 
-Retrieve an exchange rate for a given currency at a specific time.  The exchange rate is
-determined by conversion first to XRP and then to the counter currency.  The rate is
-derived from the volume weighted average over the calanendar day specified, averaged with
-the volume weighted average of the last 50 trades within the last 14 days.  If a rate
-cannot be determined, 0 is returned.
+Retrieve an exchange rate for a given currency pair at a specific time.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/exchange_rates/{:base}/{:counter}
 ```
 
-#### Params ####
-  * :base(string)...base currency of the pair in the format currency[+issuer] (required)
-  * :counter(string)...counter currency of the pair in the format currency[+issuer] (required)
-  * date (string)...UTC date for which exchange rate is determined (defaults to now)
-  * strict (boolean)...disallow rates derived from less than 10 exchanges (defaults to true)
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :base    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+| :counter | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field  | Value   | Description |
+|--------|---------|-------------|
+| date   | String - [Timestamp][] | Return an exchange rate for the specified time. Defaults to the current time. |
+| strict | Boolean | If false, allow rates derived from less than 10 exchanges. Defaults to true. |
+
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1403,38 +708,61 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
-| rate | Number | The requested exchange rate |
+| rate | Number | The requested exchange rate, or `0` if the exchange rate could not be determined. |
+
+All exchange rates are calcuated by converting the base currency and counter currency to XRP.
+
+The rate is derived from the volume weighted average over the calendar day specified, averaged with the volume weighted average of the last 50 trades within the last 14 days.
+
+#### Example ####
+
+Request: 
+
+```
+GET /v2/exchange_rates/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q/XRP?date=2015-11-13T00:00:00Z
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "rate": "224.65709"
+}
+```
+
 
 
 
 ## Normalize ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/normalize.js "Source")
 
-Convert an amount from one currency/issuer denomination to another, using network
-exchange rates. For non-XRP currencies, rates between each currency and XRP are used
-to determine a final rate, using the same logic as the exchange rate endpoint.  If a
-rate cannot be determined, 0 is used.
+Convert an amount from one currency and issuer to another, using the network exchange rates.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/normalize
 ```
 
-    date: smoment(req.query.date),
-    amount: Number(req.query.amount),
-    currency: (req.query.currency || 'XRP').toUpperCase(),
-    issuer: req.query.issuer || '',
-    exchange_currency: (req.query.exchange_currency || 'XRP').toUpperCase(),
-    exchange_issuer: req.query.exchange_issuer || '',
-    strict: (/false/i).test(req.query.strict) ? false : true
+<!--</div>-->
 
-#### Params ####
-  * amount (string)...amount of currency to normalize (required)
-  * currency(string)...original denomination currency (defaults to XRP)
-  * issuer(string)...original denomination issuer
-  * exchange_currency(string)...final denomination currency (defaults to XRP)
-  * exchange_issuer(string)...final denomination issuer
-  * date (string)...UTC date for which exchange rate is determined (defaults to now)
-  * strict (boolean)...disallow rates derived from less than 10 exchanges (defaults to true)
+This method uses the following query parameters:
+
+| Field             | Value   | Description |
+|-------------------|---------|-------------|
+| amount            | Number  | (Required) Amount of currency to normalize |
+| currency          | String - [Currency Code][] | The currency code of the `amount` to convert from. (Defaults to XRP.) |
+| issuer            | String - [Address][] | The issuer of the currency to convert from. (Required if `currency` is not XRP.) |
+| exchange\_currency | String - [Currency Code][] | The currency to convert to. (Defaults to XRP.) |
+| exchange\_issuer   | String - [Address][] | The issuer of the currency to convert to. (Required if `exchange_currency` is not XRP.) |
+| date              | String - [Timestamp][] | Convert according to the exchange rate at this time. (Defaults to the current time.) |
+| strict            | Boolean | If true, do not use exchange rates that are determined by less than 10 exchanges. (Defaults to true.) |
+
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1442,68 +770,252 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
-| amount | Number | Original denomination amount |
-| converted | Number | Final denomination amount |
-| rate | Number | Exchange rate of conversion |
+| amount | Number | Pre-conversion amount specified in the request |
+| converted | Number | Post-conversion amount of the `exchange_currency`, or `0` if the exchange rate could not be determined. |
+| rate | Number | Exchange rate used to calculate the conversion, or `0` if the exchange rate could not be determined. |
+
+All exchange rates are calculating by converting both currencies to XRP.
+
+#### Example ####
+
+Request: 
+
+```
+GET /v2/normalize?amount=100&currency=XRP&exchange_currency=USD&exchange_issuer=rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "amount": "100",
+  "converted": "0.4267798022744489",
+  "rate": "0.0042677980"
+}
+```
 
 
 
-## Get Reports ##
+
+## Get Daily Reports ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/reports.js "Source")
 
-Retreive per account per day aggregated payment summaries
+Retrieve per account per day aggregated payment summaries
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/reports/{:date}
 ```
 
-#### Params ####
-  * :date (string)...UTC query date (defaults to today)
-  * accounts (boolean)...include lists of counterparty accounts
-  * payments (boolean)...include lists of individual payments
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+This method uses the following URL parameters:
+
+| Field | Value  | Description |
+|-------|--------|-------------|
+| date  | String | (Optional) UTC query date. If omitted, use the current day. |
+
+Optionally, you can also include the following query parameters:
+
+| Field    | Value   | Description |
+|----------|---------|-------------|
+| accounts | Boolean | If true, include lists of counterparty accounts. Defaults to false. |
+| payments | Boolean | If true, include lists of individual payments. Defaults to false. |
+| format   | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response |
 
 #### Response Format ####
+
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
-| date | String | date of reports queried |
-| count | Integer | Number of reports returned |
-| marker | String | Pagination marker |
-| reports | Array of report objects | The requested reports |
+| date   | String - [Timestamp][] | The date for which this report applies. |
+| count | Integer | Number of reports returned. |
+| marker | String | (May be omitted) [Pagination](#pagination) marker. |
+| reports | Array of [Reports Objects][] | The requested reports. Each report pertains to a single account. |
+
+**WARNING:** This method may return a very large amount of data (more than 1 megabyte), which may cause poor performance in your client application.
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/reports/2015-08-19T00:00:00Z?accounts=true&payments=true
+```
+
+Response (trimmed for size):
+
+```
+{
+    "result": "success",
+    "date": "2015-08-19T00:00:00Z",
+    "count": 2,
+    "marker": "20150819000000|r2nt4zXDP6Be5FNrLsiuuTEBETbGR9RFw",
+    "reports": [
+        {
+            "account": "r2LXq2rZWSgQ1thhKiEytzi1smg6oEn8A",
+            "date": "2015-08-19T00:00:00Z",
+            "high_value_received": "7000",
+            "high_value_sent": "3400",
+            "payments": [
+                {
+                    "tx_hash": "A032EFBB219B1102BBD9BCCB91EDC6EAA8185509574FA476A2D3FE6BA79B04EF",
+                    "amount": "1700",
+                    "type": "received"
+                },
+                {
+                    "tx_hash": "8B059360DC83777CDCABA84824C169651AFD6A7AB44E8742A3B8C6BC2AAF7384",
+                    "amount": "40",
+                    "type": "received"
+                },
+                
+                ...(additional results trimmed)...
+                
+                {
+                    "tx_hash": "76041BD6546389B5EC2CDBAA543200CF7B8D300F34F908BA5CA8523B0CA158C8",
+                    "amount": "1400",
+                    "type": "sent"
+                }
+            ],
+            "payments_received": 155,
+            "payments_sent": 49,
+            "receiving_counterparties": [
+                "rDMFJrKg2jyoNG6WDWJknXDEKZ6ywNFGwD",
+                "r4XXHxraHLuCiLmLMw96FTPXXywZSnWSyR",
+                
+                ...(additional results trimmed)...
+                
+                
+                "rp1C4Ld6uGjurFpempUJ8q5hPSWhak5EQf"
+            ],
+            "sending_counterparties": [
+                "rwxcJVWZSEgN2DmLZYYjyagHjMx5jQ7BAa",
+                
+                ...(additional results trimmed)...
+                
+                
+                "rBK1rLjbWsSU9EuST1cAz9RsiYdJPVGXXA"
+            ],
+            "total_value": "210940",
+            "total_value_received": "100540",
+            "total_value_sent": "110400"
+        },
+        {
+            "account": "r2adXWaWFJt9mHeoWN77iHJozDz2FDAPA",
+            "date": "2015-08-19T00:00:00Z",
+            "high_value_received": "7400",
+            "high_value_sent": "15900",
+            "payments": [
+                {
+                    "tx_hash": "9C7EA76D467AE58E6AEFAAC7994D42FB4E7FA72BFA22F90260937386D76BDB64",
+                    "amount": "900",
+                    "type": "sent"
+                },
+                
+                ...(additional results trimmed)...
+                
+                
+                {
+                    "tx_hash": "EC25427964419394BB5D06343BC74235C33655C1F70523C688F9A201957D65BA",
+                    "amount": "100",
+                    "type": "sent"
+                }
+            ],
+            "payments_received": 43,
+            "payments_sent": 62,
+            "receiving_counterparties": [
+                "rB4cyZxrBrTmJcWZSBc8YoW2t3bafiKRp",
+                
+                ...(additional results trimmed)...
+                
+                
+                "rKybkw3Pu74VfJfrWr7QJbVPJNarnKP2EJ"
+            ],
+            "sending_counterparties": [
+                "rNRCXw8PQRjvTwMDDLZVvuLHSKqqXUXQHv",
+                "r7CLMVEuNvK2yXTPLPnkWMqzkkXuopWeL",
+                
+                ...(additional results trimmed)...
+                
+                
+                "ranyeoYRhvwiFABzDvxSVyqQKp1bMkFsaX"
+            ],
+            "total_value": "117600",
+            "total_value_received": "54700",
+            "total_value_sent": "62900"
+        }
+    ]
+}
+```
 
 
 
 ## Get Stats ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/stats.js "Source")
 
-Retreive ripple network transaction stats
+Retrieve statistics about transaction activity in the Ripple Consensus Ledger, divided into intervals of time.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/stats
-GET /v2/stats/{:family}
-GET /v2/stats/{:family}/{:metric}
 ```
 
-#### Params ####
-  * :family (string)...return only specified family ('type', 'result', or 'metric')
-  * :metric (string)...return only a specific metric from the family subset
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * interval (string)...aggregation interval:
-    * hour
-    * day
-    * week
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * descending (boolean)...reverse cronological order
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| family     | String  | If provided, filter results to a single family of stats: `type`, `result`, or `metric`. By default, provides all stats from all families. |
+| metrics    | String  | Filter results to one or more metrics (in a comma-separated list). Requires the `family` of the metrics to be specified. By default, provides all metrics in the family. |
+| start        | String - [Timestamp][] | Filter results to this time and later. |
+| end        | String - [Timestamp][] | Filter results to this time and earlier |
+| interval   | String  | Aggregation interval (`hour`,`day`,`week`, defaults to `day`) |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response. |
+| descending | Boolean | If true, return results in reverse chronological order. Defaults to false. |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+
+##### Families and Metrics #####
+
+The `family` and `metrics` query parameters provide a way to filter results to a specific subset of all metrics available for transactions in any given interval. Each metric is tied to a specific family, as follows:
+
+| Family | Included Metrics | Meaning |
+|--------|------------------|---------|
+| type | All Ripple [transaction types](https://ripple.com/build/transactions/), including `Payment`, `AccountSet`, `SetRegularKey`, `OfferCreate`, `OfferCancel`, `TrustSet`. | Number of transactions of the given type that occurred during the interval. |
+| result | All [transaction result codes](https://ripple.com/build/transactions/#transaction-results) (string codes, not the numeric codes), including `tesSUCCESS`, `tecPATH_DRY`, and many others. | Number of transactions that resulted in the given code during the interval. |
+| metric | Data-API defined Special Transaction Metrics. | (Varies) |
+
+##### Special Transaction Metrics #####
+
+The Data API derives the following values for every interval. These metrics are part of the `metric` family.
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| accounts\_created | Number | The number of new accounts funded during this interval. |
+| exchanges\_count | Number | The number of currency exchanges that occurred during this interval. |
+| ledger\_count | Number | The number of ledgers closed during this interval. |
+| ledger\_interval | Number | The average number of seconds between ledgers closing during this interval. |
+| payments\_count | Number | The number of payments from one account to another during this interval. |
+| tx\_per\_ledger | Number | The average number of transactions per ledger in this interval. |
+
+If any of the metrics have a value of 0, they are omitted from the results.
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1512,31 +1024,83 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of reports returned. |
-| marker | String | Pagination marker |
-| stats | Array of stats objects | The requested stats |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
+| stats | Array of stats objects | The requested stats. Omits metrics with a value of 0, and intervals that have no nonzero metrics. |
+
+#### Example ####
+
+Request: 
+
+```
+GET /v2/stats/?start=2015-08-30&end=2015-08-31&interval=day&family=metric&metrics=accounts_created,exchanges_count,ledger_count,payments_count
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 2,
+  "stats": [
+    {
+      "accounts_created": 15,
+      "exchanges_count": 19368,
+      "ledger_count": 20307,
+      "payments_count": 24763,
+      "date": "2015-08-30T00:00:00Z"
+    },
+    {
+      "accounts_created": 18,
+      "exchanges_count": 17192,
+      "ledger_count": 19971,
+      "payments_count": 30894,
+      "date": "2015-08-31T00:00:00Z"
+    }
+  ]
+}
+```
+
+
 
 
 ## Get Capitalization ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/capitalization.js "Source")
 
-Get capitalization data for a specific currency + issuer
+Get the total amount of a single currency issued by a single issuer, also known as the [market capitalization](https://en.wikipedia.org/wiki/Market_capitalization). _(New in [v2.0.4][])_
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
-GET /v2/capitaliztion/{:currency+issuer}
+GET /v2/capitaliztion/{:currency}
 ```
 
-#### Params ####
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * interval (string)...aggregation interval
-    * day
-    * week
-    * month
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * descending (boolean)...reverse cronological order
-  * adjusted (boolean)...adjust results by removing known issuer owned wallets
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field     | Value                      | Description |
+|-----------|----------------------------|-------------|
+| :currency | String | Currency to look up, in the form of [currency](#currency-code)+[issuer](#addresses). XRP is disallowed. |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| start      | String - [Timestamp][] | Start time of query range. Defaults to `2013-01-01T00:00:00Z`. |
+| end        | String - [Timestamp][] | End time of query range. Defaults to the current time. |
+| interval   | String  | Aggregation interval - `day`, `week`, or `month`. Defaults to `day`. |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response |
+| descending | Boolean | If true, return results in reverse chronological order. Defaults to false. |
+| adjusted   | Boolean | If true, do not count known issuer-owned wallets towards market capitalization. Defaults to true. |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+
+If the request omits both `start` and `end`, the API returns only the most recent sample.
 
 
 #### Response Format ####
@@ -1548,31 +1112,113 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | count | Integer | Number of reports returned. |
 | currency | String | Currency requested |
 | issuer | String | Issuer requested |
-| marker | String | Pagination marker |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
 | rows | Array of issuer capitalization objects | The requested capitalization data |
+
+Each **issuer capitalization object** has the following fields:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| date   | String - [Timestamp][] | The start time of the interval this object represents. |
+| amount | [String - Number][] | The total amount of currency issued by the issuer as of the start of this interval. |
+
+#### Example ####
+
+Request: 
+
+```
+GET /v2/capitalization/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q?start=2015-01-01T00:00:00Z&end=2015-10-31&interval=month
+```
+
+Response:
+
+```
+200 OK
+{
+  "result": "success",
+  "currency": "USD",
+  "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+  "count": 10,
+  "rows": [
+    {
+      "date": "2015-01-01T00:00:00Z",
+      "amount": "4212940.254176095"
+    },
+    {
+      "date": "2015-02-01T00:00:00Z",
+      "amount": "5102817.663782776"
+    },
+    {
+      "date": "2015-03-01T00:00:00Z",
+      "amount": "4179270.8503426993"
+    },
+    {
+      "date": "2015-04-01T00:00:00Z",
+      "amount": "2609239.954946732"
+    },
+    {
+      "date": "2015-05-01T00:00:00Z",
+      "amount": "2262976.3681027396"
+    },
+    {
+      "date": "2015-06-01T00:00:00Z",
+      "amount": "2401904.277326213"
+    },
+    {
+      "date": "2015-07-01T00:00:00Z",
+      "amount": "2007614.760195671"
+    },
+    {
+      "date": "2015-08-01T00:00:00Z",
+      "amount": "2286058.6013003727"
+    },
+    {
+      "date": "2015-09-01T00:00:00Z",
+      "amount": "2070512.4729615194"
+    },
+    {
+      "date": "2015-10-01T00:00:00Z",
+      "amount": "2140238.7719266433"
+    }
+  ]
+}
+```
+
 
 
 
 ## Get Active Accounts ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/activeAccounts.js "Source")
 
-Get active trading accounts for a specific currency pair
+Get information on which accounts are actively trading in a specific currency pair. _(New in [v2.0.4][])_
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/active_accounts/{:base}/{:counter}
 ```
 
-#### Params ####
-  * :base(string)...base currency of the pair in the format currency[+issuer] (required)
-  * :counter(string)...counter currency of the pair in the format currency[+issuer] (required)
-  * period (string)...requested period
-    * 1day
-    * 3day
-    * 7day
-  * date (string)... start date for the selected period. If absent, the latest period is used.
-  * include_exchanges(boolean)...include individual exchanges for each account in the results.
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :base    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+| :counter | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+
+Optionally, you can also include the following query parameters:
+
+| Field              | Value   | Description |
+|--------------------|---------|-------------|
+| period             | String  | Get results for trading activity during a chosen time period. Valid periods are `1day`, `3day`, or `7day`. Defaults to `1day`. |
+| date               | String  | Get results for the period starting at this time. Defaults to the most recent period available. |
+| include\_exchanges | Boolean | Include individual exchanges for each account in the results. |
+| format             | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1581,32 +1227,146 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of accounts returned. |
-| exchanges_count | Integer | Total number of exchanges. |
-| accounts | Array of active account objects | Active trading accounts for the period |
+| exchanges\_count | Integer | Total number of exchanges in the period. |
+| accounts | Array of active Account Trading Objects | Active trading accounts for the period |
+
+Each "Account Trading Object" describes the activity of a single account during the period, and has the following fields:
+
+| Field           | Value            | Description |
+|-----------------|------------------|-------------|
+| buy             | Object | Summary of currency exchanges buying the base currency|
+| buy.base\_volume | Number | Amount of base currency the account bought in this period. |
+| buy.counter\_volume | Number | Amount of counter currency the account sold in this period. |
+| buy.count       | Number | Number of trades that bought the base currency in this period. |
+| sell            | Object | Summary of currency changes selling the base currency |
+| sell.base\_volume | Number | Amount of the base currency the account sold this period. |
+| sell.counter\_volume | Number | Amount of the counter currency the account bought this period. |
+| sell.count      | Number | Number of trades that sold the base currency. |
+| account         | String - Address | The address whose activity this object describes |
+| base\_volume    | Number | The total volume of the base currency the account bought and sold in this period. |
+| counter\_volume | Number | The total volume of the counter currency the account bought and sold in this period. |
+| count           | Number | The total number of exchanges the account made during this period. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/active_accounts/XRP/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q
+```
+
+Response:
+
+```
+{
+    "result": "success",
+    "count": 12,
+    "exchanges_count": 11,
+    "accounts": [
+        {
+            "buy": {
+                "base_volume": 0,
+                "counter_volume": 0,
+                "count": 0
+            },
+            "sell": {
+                "base_volume": 13084.822874,
+                "counter_volume": 54.499328645454604,
+                "count": 4
+            },
+            "account": "rGBQhB8EH5DmqMmfKPLchpqr3MR19pv6zN",
+            "base_volume": 13084.822874,
+            "counter_volume": 54.499328645454604,
+            "count": 4
+        },
+        {
+            "buy": {
+                "base_volume": 12597.822874,
+                "counter_volume": 52.4909286454546,
+                "count": 1
+            },
+            "sell": {
+                "base_volume": 0,
+                "counter_volume": 0,
+                "count": 0
+            },
+            "account": "rQE5Z3FgVnRMbVfS6xiVQFgB4J3X162FVD",
+            "base_volume": 12597.822874,
+            "counter_volume": 52.4909286454546,
+            "count": 1
+        },
+        
+        ... (additional results trimmed)...
+        
+        {
+            "buy": {
+                "base_volume": 1.996007,
+                "counter_volume": 0.008782427920595,
+                "count": 1
+            },
+            "sell": {
+                "base_volume": 0,
+                "counter_volume": 0,
+                "count": 0
+            },
+            "account": "rD8LigXE7165r3VWhSQ4FwzJy7PNrTMwUq",
+            "base_volume": 1.996007,
+            "counter_volume": 0.008782427920595,
+            "count": 1
+        },
+        {
+            "buy": {
+                "base_volume": 0,
+                "counter_volume": 0,
+                "count": 0
+            },
+            "sell": {
+                "base_volume": 0.1,
+                "counter_volume": 0.0004821658905462904,
+                "count": 1
+            },
+            "account": "rfh3pFHkCXv3TgzsEJgyCzF1CduZHCLi9o",
+            "base_volume": 0.1,
+            "counter_volume": 0.0004821658905462904,
+            "count": 1
+        }
+    ]
+}
+```
 
 
 
 ## Get Exchange Volume ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getMetric.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/getMetric.js "Source")
 
-Get aggregated exchange volume for a given time period. By default, the rolling 24 hour
-data is returned. If start or end is specified, historical intervals are returned.
+Get aggregated exchange volume for a given time period. _(New in [v2.0.4][])_
+
+The API returns results in units of a single _display currency_ rather than many different currencies. The conversion uses standard rates to and from XRP.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/network/exchange_volume
 ```
 
-#### Params ####
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * interval (string)...aggregation interval
-    * day
-    * week
-    * month
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+Optionally, you can include the following query parameters:
+
+| Field    | Value   | Description |
+|----------|---------|-------------|
+| start      | String - [Timestamp][]  | Start time of query range. Defaults to the start of the most recent interval. |
+| end        | String - [Timestamp][]  | End time of query range. Defaults to the end of the most recent interval. |
+| interval | String  | Aggregation interval - valid intervals are `day`, `week`, or `month`. Defaults to `day`. |
+| exchange\_currency | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
+| exchange\_issuer | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
+| limit    | Integer | Max results per page. Defaults to 200. Cannot be more than 1000. |
+| marker   | String  | [Pagination](#pagination) key from previously returned response |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1615,31 +1375,144 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of results returned. |
-| rows | Array of exchange volume objects | Exchange volumes for the period selected |
+| rows | Array of exchange [Volume Objects][] | Exchange volumes for each interval in the requested time period. (By default, this method only returns the most recent interval.) |
+
+Each object in the `components` array of the Volume Objects represent the volume of exchanges in a market between two currencies, and has the following fields:
+
+| Field  | Value  | Description |
+|--------|--------|-------------|
+| count  | Number | The number of exchanges in this market during this interval. |
+| rate   | Number | The exchange rate from the base currency to the display currency. |
+| amount | Number | The amount of volume in the market, in units of the base currency. |
+| base   | Object | The `currency` and `issuer` that identify the base currency of this market. There is no `issuer` for XRP. |
+| counter | Object | The `currency` and `issuer` that identify the counter currency of this market. There is no `issuer` for XRP. |
+| convertedAmount | Number | The total amount of volume in the market, converted to the display currency. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/network/exchange_volume?exchange_currency=USD&exchange_issuer=rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B
+```
+
+
+Response:
+
+```
+{
+    "result": "success",
+    "count": 1,
+    "rows": [
+        {
+            "components": [
+                {
+                    "count": 1711,
+                    "rate": 5.514373809662552e-8,
+                    "amount": 333.7038784107369,
+                    "base": {
+                        "currency": "BTC",
+                        "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                    "counter": {
+                        "currency": "XRP"
+                    },
+                    "convertedAmount": 117720.99268355068
+                },
+                {
+                    "count": 1977,
+                    "rate": 0.000019601413454357618,
+                    "amount": 74567.72531650064,
+                    "base": {
+                        "currency": "USD",
+                        "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                    "counter": {
+                        "currency": "XRP"
+                    },
+                    "convertedAmount": 74003.51871932109
+                },
+                
+                ... (additional results trimmed) ...
+                
+                {
+                    "count": 3,
+                    "rate": 0.022999083584408355,
+                    "amount": 85.40728674708998,
+                    "base": {
+                        "currency": "CNY",
+                        "issuer": "razqQKzJRdB4UxFPWf5NEpEG3WMkmwgcXA"
+                    },
+                    "counter": {
+                        "currency": "USD",
+                        "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+                    },
+                    "convertedAmount": 12.72863756671683
+                },
+                {
+                    "count": 3,
+                    "rate": 1.7749889023209692e-7,
+                    "amount": 570.687912196755,
+                    "base": {
+                        "currency": "JPY",
+                        "issuer": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN"
+                    },
+                    "counter": {
+                        "currency": "BTC",
+                        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+                    },
+                    "convertedAmount": 4.4137945368632545
+                }
+            ],
+            "count": 11105,
+            "endTime": "2015-09-11T19:58:58+00:00",
+            "exchange": {
+                "currency": "USD",
+                "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+            },
+            "exchangeRate": 0.004410567085248279,
+            "startTime": "2015-11-10T00:06:04+00:00",
+            "total": 442442.5974313684
+        }
+    ]
+}
+```
+
+
 
 
 
 ## Get Payment Volume ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getMetric.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/getMetric.js "Source")
 
-Get aggregated payment volume for a given time period. By default, the rolling 24 hour
-data is returned. If start or end is specified, historical intervals are returned.
+Get aggregated payment volume for a given time period. _(New in [v2.0.4][])_
+
+The API returns results in units of a single _display currency_ rather than many different currencies. The conversion uses standard rates to and from XRP.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/network/payment_volume
 ```
 
-#### Params ####
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * interval (string)...aggregation interval
-    * day
-    * week
-    * month
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+Optionally, you can include the following query parameters:
+
+| Field    | Value   | Description |
+|----------|---------|-------------|
+| start      | String - [Timestamp][]  | Start time of query range. Defaults to the start of the most recent interval. |
+| end        | String - [Timestamp][]  | End time of query range. Defaults to the end of the most recent interval. |
+| interval | String  | Aggregation interval - valid intervals are `day`, `week`, or `month`. Defaults to `day`. |
+| exchange\_currency | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
+| exchange\_issuer | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
+| limit    | Integer | Max results per page. Defaults to 200. Cannot be more than 1000. |
+| marker   | String  | [Pagination](#pagination) key from previously returned response |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1648,62 +1521,477 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of results returned. |
-| rows | Array of payment volume objects | Payment volumes for the period selected |
+| rows | Array of payment [Volume Objects][] | Payment volumes for each interval in the requested time period. (By default, this method only returns the most recent interval.) |
+
+Each object in the `components` array of the Volume Objects represent the volume of payments for one currencies and issuer, and has the following fields:
+
+| Field  | Value  | Description |
+|--------|--------|-------------|
+| currency | String - [Currency Code][] | The currency of this payment volume object. |
+| issuer | String - [Address][] | (Omitted for XRP) The issuer of this payment volume object. |
+| amount | Number | Total payment volume for this currency during the interval, in units of the currency itself. |
+| count  | Number | The total number of payments in this currency |
+| rate   | Number | The exchange rate between this currency and the display currency. |
+| convertedAmount | Number | Total payment volume for this currency, converted to the display currency. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/network/payment_volume
+```
+
+Response:
+
+```
+{
+    "result": "success",
+    "count": 1,
+    "rows": [
+        {
+            "components": [
+                {
+                    "currency": "USD",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "amount": 87279.59029136538,
+                    "count": 331,
+                    "rate": 0.004412045860957953,
+                    "convertedAmount": 19782113.1153009
+                },
+                {
+                    "currency": "USD",
+                    "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+                    "amount": 0,
+                    "count": 0,
+                    "rate": 0.00451165816091143,
+                    "convertedAmount": 0
+                },
+                {
+                    "currency": "BTC",
+                    "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+                    "amount": 279.03077460240354,
+                    "count": 107,
+                    "rate": 0.000013312520335244644,
+                    "convertedAmount": 20960026.169024874
+                },
+                
+                ... (additional results trimmed) ...
+                
+                {
+                    "currency": "MXN",
+                    "issuer": "rG6FZ31hDHN1K5Dkbma3PSB5uVCuVVRzfn",
+                    "amount": 49263.13280138676,
+                    "count": 19,
+                    "rate": 0.07640584677247926,
+                    "convertedAmount": 644756.0609868265
+                },
+                {
+                    "currency": "XRP",
+                    "amount": 296246369.30089426,
+                    "count": 8691,
+                    "rate": 1,
+                    "convertedAmount": 296246369.30089426
+                }
+            ],
+            "count": 9388,
+            "endTime": "2015-09-11T19:58:59+00:00",
+            "exchange": {
+                "currency": "XRP"
+            },
+            "exchangeRate": 1,
+            "startTime": "2015-11-10T00:19:04+00:00",
+            "total": 390754174.7837752
+        }
+    ]
+}
+```
 
 
 
 ## Get Issued Value ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getMetric.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/network/getMetric.js "Source")
 
-Get aggregated currency capitalization for a given time period. By default, the rolling 24 hour
-data is returned. If start or end is specified, historical intervals are returned.
+Get the total value of all currencies issued by a selection of major gateways over time. By default, returns only the most recent measurement. _(New in [v2.0.4][])_
+
+The API returns results in units of a single _display currency_ rather than many different currencies. The conversion uses standard rates to and from XRP.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/network/issued_value
 ```
 
-#### Params ####
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+Optionally, you can include the following query parameters:
+
+| Field  | Value   | Description |
+|--------|---------|-------------|
+| start      | String - [Timestamp][]  | Start time of query range. Defaults to the start of the most recent interval. |
+| end        | String - [Timestamp][]  | End time of query range. Defaults to the end of the most recent interval. |
+| exchange\_currency | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
+| exchange\_issuer | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
+| limit    | Integer | Max results per page. Defaults to 200. Cannot be more than 1000. |
+| marker   | String  | [Pagination](#pagination) key from previously returned response |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 #### Response Format ####
+
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of results returned. |
-| rows | Array of issued value objects | Aggregated capitalization for the period selected |
+| rows | Array of Issued Value Objects | Aggregated capitalization at the requested point(s) in time. |
+
+Each Issued Value Object represents the total value issued at one point in time, and has the following fields:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| components | Array of Objects | The data on individual issuers that was used to assemble this total. |
+| exchange | Object | Indicates the display currency used, as with fields `currency` and (except for XRP) `issuer`. All amounts are normalized by first converting to XRP, and then to the display currency specified in the request. |
+| exchangeRate | Number | The exchange rate to the displayed currency from XRP. 
+| time | String - [Timestamp][] | The time at which this data was measured. |
+| total | Number | Total value of all issued assets at this time, in units of the display currency. |
+
+#### Example ####
+
+Request: 
+
+```
+GET /v2/network/issued_value?start=2015-10-01T00:00:00&end=2015-10-01T00:00:00&exchange_currency=USD&exchange_issuer=rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 1,
+  "rows": [
+    {
+      "components": [
+        {
+          "currency": "USD",
+          "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+          "amount": "2177473.2843876695",
+          "rate": "0.000028818194",
+          "converted_amount": "2166521.1303508882"
+        },
+        {
+          "currency": "USD",
+          "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+          "amount": "1651297.315492664",
+          "rate": "0.000028888001",
+          "converted_amount": "1639021.4313562333"
+        },
+        
+        ... (additional results trimmed for size) ...
+        
+        {
+          "currency": "MXN",
+          "issuer": "rG6FZ31hDHN1K5Dkbma3PSB5uVCuVVRzfn",
+          "amount": "2288827.2376308907",
+          "rate": "0.00050850375",
+          "converted_amount": "129061.20018881827"
+        }
+      ],
+      "exchange": {
+        "currency": "USD",
+        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+      },
+      "total": "8338101.394233938",
+      "exchange_rate": "0.0053547404",
+      "date": "2015-10-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+
+
+
+## Get All Gateways ##
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/gateways.js "Source")
+
+Get information about [known gateways](https://github.com/ripple/rippled-historical-database/blob/v2.0.4/api/gateways/gateways.json). _(New in [v2.0.4][])_
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
+
+```
+GET /v2/gateways/
+```
+
+<!--</div>-->
+
+This method takes no query parameters.
+
+
+#### Response Format ####
+
+A successful response uses the HTTP code **200 OK** and has a JSON body.
+
+Each field in the top level JSON object is a [Currency Code][]. The content of each field is an array of objects, representing gateways that issue that currency. Each object has the following fields:
+
+| Field    | Value   | Description |
+|----------|---------|-------------|
+| name     | String  | A human-readable proper name for the gateway. |
+| account  | String - [Address][] | The issuing account (cold wallet) that issues the currency. |
+| featured | Boolean | Whether this gateway is considered a "featured" issuer of the currency. Ripple, Inc. decides which gateways to feature based on responsible business practices, volume, and other measures. |
+| label    | String  | (May be omitted) Only provided when the [Currency Code][] is a 40-character hexadecimal value. This is an alternate human-readable name for the currency issued by this gateway.
+| assets   | Array of Strings | Graphics filenames available for this gateway, if any. (Mostly, these are logos used by Ripple Charts.) |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/gateways/
+```
+
+Response:
+
+```
+{
+    "AUD": [
+        {
+            "name": "Bitstamp",
+            "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "featured": false,
+            "assets": [
+                "logo.grayscale.svg",
+                "logo.svg"
+            ]
+        },
+        {
+            "name": "Coinex",
+            "account": "rsP3mgGb2tcYUrxiLFiHJiQXhsziegtwBc",
+            "featured": false,
+            "assets": []
+        }
+    ],
+
+... (additional results trimmed) ...
+
+    "0158415500000000C1F76FF6ECB0BAC600000000": [
+        {
+            "name": "GBI",
+            "account": "rrh7rf1gV2pXAoqA8oYbpHd8TKv5ZQeo67",
+            "featured": false,
+            "label": "XAU (-0.5pa)",
+            "assets": []
+        }
+    ],
+    "KRW": [
+        {
+            "name": "EXRP",
+            "account": "rPxU6acYni7FcXzPCMeaPSwKcuS2GTtNVN",
+            "featured": true,
+            "assets": []
+        },
+        {
+            "name": "Pax Moneta",
+            "account": "rUkMKjQitpgAM5WTGk79xpjT38DEJY283d",
+            "featured": false,
+            "assets": []
+        }
+    ]
+}
+```
+
+
+
+## Get Gateway ##
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/gateways.js "Source")
+
+Get information about a specific gateway from [the Data API's list of known gateways](https://github.com/ripple/rippled-historical-database/blob/v2.0.4/api/gateways/gateways.json). _(New in [v2.0.4][])_
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
+
+```
+GET /v2/gateways/{:gateway}
+```
+
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| :gateway | String | The issuing [Address][], [URL-encoded name](https://en.wikipedia.org/wiki/Percent-encoding), or normalized name of the gateway. |
+
+This method takes no query parameters.
+
+#### Response Format ####
+
+A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
+
+| Field       | Value  | Description |
+|-------------|--------|-------------|
+| name        | String | Human-readable name of the gateway
+| start\_date | String - [Timestamp][] | The approximate date of the first time exchanges for this gateway's currencies appeared in the ledger. |
+| accounts    | Array | A list of [issuing accounts](https://ripple.com/build/gateway-guide/#hot-and-cold-wallets) (cold wallets) used by this gateway. (Gateways may use different issuing accounts for different currencies.) |
+| hotwallets  | Array of [Address][]es | The addresses of the Ripple accounts this gateway uses as [hot wallets](https://ripple.com/build/gateway-guide/#hot-and-cold-wallets). |
+| domain      | String | The domain name where this gateway does business. Typically the gateway hosts a [`ripple.txt`](https://wiki.ripple.com/Ripple.txt) there. |
+| normalized  | String | A normalized version of the `name` field suitable for including in URLs. |
+| assets      | Array of Strings | Graphics filenames available for this gateway, if any. (Mostly, these are logos used by Ripple Charts.) |
+
+Each object in the `accounts` field array has the following fields:
+
+| Field      | Value  | Description |
+|------------|--------|-------------|
+| address    | String | The [Address][] of an [issuing account](https://ripple.com/build/gateway-guide/#hot-and-cold-wallets) (cold wallet) used by this gateway. |
+| currencies | Object | Each field in this object is a [Currency Code][] corresponding to a currency issued from this address. Each value is an object with a `featured` boolean indicating whether that currency is featured. Ripple, Inc. decides which currencies and gateways to feature based on responsible business practices, volume, and other measures. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/gateways/Gatehub
+```
+
+Response:
+
+```
+200 OK
+{
+    "name": "Gatehub",
+    "start_date": "2015-02-15T00:00:00Z",
+    "accounts": [
+        {
+            "address": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq",
+            "currencies": {
+                "EUR": {
+                    "featured": true
+                },
+                "USD": {
+                    "featured": true
+                }
+            }
+        }
+    ],
+    "hotwallets": [
+        "rhotcWYdfn6qxhVMbPKGDF3XCKqwXar5J4"
+    ],
+    "domain": "gatehub.net",
+    "normalized": "gatehub",
+    "assets": [
+        "logo.grayscale.svg",
+        "logo.svg"
+    ]
+}
+```
+
+
+
+
+## Get Currency Image ##
+
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/v0.0.4-rc2/api/routesV2/gateways.js#L196 "Source")
+
+Retrieve vector icons for various currencies. _(New in [v2.0.4][])_
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
+
+```
+GET /v2/currencies/{:currencyimage}
+```
+
+<!--</div>-->
+
+This method requires the following URL parameter:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| :currencyimage | String | An image file for a currency, such as `xrp.svg`. See [the source code](https://github.com/ripple/rippled-historical-database/tree/develop/api/gateways/currencyAssets) for a list of available images. |
+
+#### Response Format ####
+A successful response uses the HTTP code **200 OK** and has a **Content-Type** header of `image/svg+xml` to indicate that the contents are XML representing a file in [SVG format](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics).
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/currencies/mxn.svg
+```
+
+Response
+
+```
+200 OK
+Content-Type: image/svg+xml
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="200px" height="200px" viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
+<g>
+	<path fill="#FC6E74" d="M105.1,181.5c-12.2,0-24-2.1-35.1-6.2c-11.1-4.1-21.6-10.5-31.1-19.1l-1.3-1.2l18.8-22.3l1.4,1.2
+		c7.4,6.4,14.9,11.3,22.4,14.7c7.4,3.4,16,5.1,25.5,5.1c8,0,14.4-1.7,19-5c4.5-3.2,6.7-7.3,6.7-12.7c0-3-0.4-5.2-1.3-7.1
+		c-0.8-1.8-2.4-3.6-4.8-5.4c-2.4-1.8-5.9-3.5-10.2-5.1c-4.5-1.6-10.3-3.2-17.5-4.8c-8.3-1.9-15.8-4.1-22.4-6.6
+		c-6.6-2.5-12.3-5.6-16.8-9.2C54,94.3,50.4,89.8,48,84.5c-2.4-5.2-3.6-11.6-3.6-18.9c0-7.4,1.4-13.8,4.1-19.5
+		c2.7-5.8,6.6-10.7,11.4-14.8c4.8-4.1,10.6-7.3,17.3-9.5c6.7-2.3,14-3.4,21.9-3.4c11.6,0,22.2,1.7,31.4,5.1
+		c9.3,3.4,18.1,8.4,26.2,14.8l1.4,1.1l-16.8,23.6l-1.5-1.1c-6.9-5-13.9-9-20.7-11.6c-6.7-2.6-13.6-4-20.4-4
+		c-7.5,0-13.4,1.6-17.5,4.9c-4,3.2-6,7-6,11.6c0,3.1,0.5,5.5,1.4,7.5c0.9,2,2.6,3.8,5,5.4c2.6,1.8,6.3,3.4,10.9,5
+		c4.8,1.6,10.9,3.3,18.2,5c8.3,2.1,15.7,4.4,22,7c6.5,2.6,12,5.8,16.3,9.5c4.3,3.8,7.7,8.3,9.9,13.3c2.2,5,3.4,10.9,3.4,17.5
+		c0,7.9-1.4,14.7-4.2,20.7c-2.8,6-6.8,11.1-11.9,15.3c-5,4.1-11.1,7.3-18.1,9.4C121.2,180.5,113.4,181.5,105.1,181.5z"/>
+	<rect x="86.7" y="0" fill="#FC6E74" width="26.5" height="40.1"/>
+	<rect x="86.5" y="159.2" fill="#FC6E74" width="27" height="40.8"/>
+</g>
+</svg>
+```
 
 
 
 ## Get Accounts ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accounts.js "Source")
 
-Get funded ripple network accounts
+Retrieve information about the creation of new accounts in the Ripple Consensus Ledger.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/accounts
 ```
 
-#### Params ####
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * interval (string)...aggregation interval
-    * hour
-    * day
-    * week
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * descending (boolean)...reverse cronological order
-  * parent (string)...limit results to specified parent account
-  * reduce (boolean)...return a count of results only
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+Optionally, you can include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| start      | String - [Timestamp][]  | Start time of query range |
+| end        | String - [Timestamp][]  | End time of query range |
+| interval   | String  | Aggregation interval (`hour`,`day`,`week`). If omitted, return individual accounts. Not compatible with the `parent` parameter. |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1,000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response |
+| descending | Boolean | Reverse chronological order |
+| parent     | String  | Filter results to children of the specified parent account. Not compatible with the `interval` parameter. |
+| reduce     | Boolean | Return a count of results only |
+| format     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1711,54 +1999,155 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
-| count | Integer | Number of reports returned. |
-| marker | String | Pagination marker |
-| stats | Array of account creation objects | The requested accounts |
+| count  | Integer | Number of reports returned. |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
+| accounts | Array | If the request used the `interval` query parameter, each member of the array is an interval object. Otherwise, this field is an array of [account creation objects](#account-creation-objects). |
 
+##### Interval Objects #####
+
+If the request uses the `interval` query parameter, the response has an array of interval objects, each of which represents the number of accounts created during a single interval. Interval objects have the following fields:
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| date   | String - [Timestamp] | The time at which this interval starts. (The length of the interval is determined by the request.) |
+| count  | Number | How many accounts were created in this interval. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v1/accounts?parent=rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 3,
+  "accounts": [
+    {
+      "balance": "20.0",
+      "account": "raKEEVSGnKSD9Zyvxu4z6Pqpm4ABH8FS6n",
+      "executed_time": "2015-02-09T23:31:40+00:00",
+      "ledger_index": 11620700,
+      "parent": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "tx_hash": "1D381C0FCA00E8C34A6D4D3A91DAC9F3697B4E66BC49ED3D9B2D6F57D7F15E2E"
+    },
+    {
+      "balance": "30",
+      "account": "rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v",
+      "executed_time": "2015-06-16T21:15:40+00:00",
+      "ledger_index": 14090928,
+      "parent": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "tx_hash": "60B614622FC67DFCA8D796D7F6AF0B7AEC5E59BB268EA032F810395407DDF8D5"
+    },
+    {
+      "balance": "50",
+      "account": "rLFd1FzHMScFhLsXeaxStzv3UC97QHGAbM",
+      "executed_time": "2015-09-23T23:05:20+00:00",
+      "ledger_index": 16061430,
+      "parent": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "tx_hash": "FAE331A6D5CB83BCE832E7EBEDBD807EDEFFAF39AB241683EE81A0326A1A6748"
+    }
+  ]
+}
+```
 
 
 ## Get Account ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getaccount.js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/getAccount.js "Source")
 
 Get creation info for a specific ripple account
 
+#### Request Format ####
+
+
+<!--<div class='multicode'>-->
+
+*REST*
+
 ```
-GET /v2/account/{:address}
+GET /v2/accounts/{:address}
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
+<!--</div>-->
 
+
+This method requires the following URL parameters:
+
+| Field   | Value  | Description |
+|---------|--------|-------------|
+| address | String | Ripple address to query |
 
 #### Response Format ####
+
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
-| account | account creation object | The requested account |
+| account | Object - [Account Creation](#account-creation-objects) | The requested account |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn
+```
+
+Response:
+
+```
+{
+    "result": "success",
+    "account": {
+        "address": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+        "parent": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+        "initial_balance": "100.0",
+        "inception": "2014-05-29T17:05:20+00:00",
+        "ledger_index": 6902264,
+        "tx_hash": "074415C5DC6DB0029E815EA6FC2629FBC29A2C9D479F5D040AFF94ED58ECC820"
+    }
+}
+```
 
 
 
 ## Get Account Balances ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountBalances .js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountBalances.js "Source")
 
-Get balances for a specific ripple account
+Get all balances held or owed by a specific Ripple account.
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
-GET /v2/account/{:address}/balances
+GET /v2/accounts/{:address}/balances
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
-  * ledger_index (integer)...index of ledger for historical balances
-  * ledger_hash (string)...ledger hash for historical balances
-  * date (string)...UTC date for historical balances
-  * currency(string)...restrict results to specified currency
-  * issuer(string)...restrict results to specified counterparty/issuer
-  * limit (integer)...max results per page (defaults to 200)
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| address | String | Ripple address to query |
+
+Optionally, you can also include the following query parameters:
+
+| Field        | Value   | Description |
+|--------------|---------|-------------|
+| ledger_index | Integer | Index of ledger for historical balances |
+| ledger_hash  | String  | Ledger hash for historical balances |
+| date         | String  | UTC date for historical balances. |
+| currency     | String  | Restrict results to specified currency |
+| issuer       | String  | Restrict results to specified counterparty/issuer |
+| limit        | Integer | Max results per page (defaults to 200). Cannot be greater than 400, but you can use the value `all` to return all results. (Caution: When using limit=all to retrieve very many results, the request may time out. Large gateways can have several tens of thousands of results.) |
+| format       | String  | Format of returned results: `csv`,`json` defaults to `json` |
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1769,27 +2158,95 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | ledger_index | Integer | ledger index for balances query |
 | close_time | String | close time of the ledger |
 | limit | String | number of results returned, if limit was exceeded |
-| balances | Array of balance objects | The requested balances |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
+| balances | Array of [Balance Object][]s | The requested balances |
 
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/balances?date=2015-08-01T00:00:00Z
+```
+
+Response:
+
+```
+{
+    "result": "success",
+    "ledger_index": 14979795,
+    "close_time": "2015-08-01T00:00:00",
+    "validated": true,
+    "balances": [
+        {
+            "value": "148.446663",
+            "currency": "XRP",
+            "counterparty": ""
+        },
+        {
+            "value": "-11.0301",
+            "currency": "USD",
+            "counterparty": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX"
+        },
+        {
+            "value": "0.0001",
+            "currency": "USD",
+            "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+        },
+        {
+            "value": "0",
+            "currency": "USD",
+            "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        },
+        {
+            "value": "10",
+            "currency": "USD",
+            "counterparty": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW"
+        },
+        {
+            "value": "0",
+            "currency": "USD",
+            "counterparty": "rUpy3eEg8rqjqfUoLeBnZkscbKbFsKXC3v"
+        }
+    ]
+}
+```
 
 
 ## Get Account Orders ##
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountOrders .js "Source")
+[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountOrders.js "Source")
 
-Get orders for a specific ripple account
+Get orders in the order books, placed by a specific account. This does not return orders that have already been filled.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/account/{:address}/orders
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
-  * ledger_index (integer)...index of ledger for historical orders
-  * ledger_hash (string)...ledger hash for historical orders
-  * date (string)...UTC date for historical orders
-  * limit (integer)...max results per page (defaults to 200)
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
 
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| address  | String - [Address][] | Ripple address to query |
+
+Optionally, you can also include the following query parameters:
+
+| Field         | Value   | Description |
+|---------------|---------|-------------|
+| ledger\_index | Integer | Get orders as of this ledger. Not compatible with `ledger_hash` or `date`. |
+| ledger\_hash  | String  | Get orders as of this ledger. Not compatible with `ledger_index` or `date`. |
+| date          | String - [Timestamp][] | Get orders at this time. Not compatible with `ledger_index` or `ledger_hash`. |
+| limit         | Integer | Max results per page (defaults to 200). Cannot be greater than 400. |
+| format        | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+
+If none of `ledger_index`, `ledger_hash`, or `date` are specified, the API uses the most current data available.
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1797,35 +2254,128 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
-| ledger_index | Integer | ledger index for orders query |
-| close_time | String | close time of the ledger |
-| limit | String | number of results returned, if limit was exceeded |
+| ledger\_index | Integer | `ledger_index` of the ledger version used. |
+| close\_time | String | Close time of the ledger version used. |
+| limit | String | The `limit` from the request. |
 | orders | Array of order objects | The requested orders |
 
+Each order object has the following fields:
+
+| Field                        | Value  | Description |
+|------------------------------|--------|-------------|
+| specification                | Object | Details of this order's current state. |
+| specification.direction      | String | Either `buy` or `sell` |
+| specification.quantity       | [Balance Object][] | The maximum amount of the base currency this order would buy or sell (depending on the direction). This value decreases as the order gets partially filled. |
+| specification.totalPrice     | [Balance Object][] | The maximum amount of the counter currency that will be spent or gained in order to buy or sell the base currency. This value decreases as the order gets partially filled. |
+| properties                   | Object | Details of how the order was placed. |
+| properties.maker             | String - [Address][] | The Ripple account that placed the order. |
+| properties.sequence          | Number | The sequence number of the transaction that placed this order. |
+| properties.makerExchangeRate | [String - Number][] | The exchange rate from the point of view of the account that submitted the order. |
+
+#### Example ####
+
+Request: 
+
+```
+GET /v2/accounts/rK5j9n8baXfL4gzUoZsfxBvvsv97P5swaV/orders?limit=2&date=2015-11-11T00:00:00Z
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "ledger_index": 17007855,
+  "close_time": "2015-11-11T00:00:00Z",
+  "limit": 2,
+  "orders": [
+    {
+      "specification": {
+        "direction": "buy",
+        "quantity": {
+          "currency": "JPY",
+          "value": "56798.00687665813",
+          "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN"
+        },
+        "totalPrice": {
+          "currency": "USD",
+          "value": "433.792841227449",
+          "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+        }
+      },
+      "properties": {
+        "maker": "rK5j9n8baXfL4gzUoZsfxBvvsv97P5swaV",
+        "sequence": 7418286,
+        "makerExchangeRate": "130.9334813270407"
+      }
+    },
+    {
+      "specification": {
+        "direction": "buy",
+        "quantity": {
+          "currency": "JPY",
+          "value": "11557.02705273459",
+          "counterparty": "r94s8px6kSw1uZ1MV98dhSRTvc6VMPoPcN"
+        },
+        "totalPrice": {
+          "currency": "USD",
+          "value": "87.570156003591",
+          "counterparty": "rhub8VRN55s94qWKDv6jmDy1pUykJzF3wq"
+        }
+      },
+      "properties": {
+        "maker": "rK5j9n8baXfL4gzUoZsfxBvvsv97P5swaV",
+        "sequence": 7418322,
+        "makerExchangeRate": "131.9744942815983"
+      }
+    }
+  ]
+}
+```
 
 
-## Get Account Transactions V2 ##
+
+
+## Get Account Transaction History ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountTransactions.js "Source")
 
 Retrieve a history of transactions that affected a specific account. This includes all transactions the account sent, payments the account received, and payments that rippled through the account.
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/accounts/{:address}/transactions
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * min_sequence (string)...minimum sequence number to query
-  * max_sequence (string)...max sequence number to query
-  * type(string)...restrict results to a specified transaction type
-  * result(string)...restrict results to specified transaction result
-  * binary (boolean)..return results in binary format
-  * descending (boolean)...reverse cronological order
-  * limit (integer)...max results per page (defaults to 20)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :address | String - [Address][] | Ripple address to query |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field        | Value   | Description |
+|--------------|---------|-------------|
+| start        | String  | UTC start time of query range |
+| end          | String  | UTC end time of query range |
+| min_sequence | String  | Minimum sequence number to query |
+| max_sequence | String  | Max sequence number to query |
+| type         | String  | Restrict results to a specified [transaction type](https://ripple.com/build/transactions/) |
+| result       | String  | Restrict results to specified transaction result |
+| binary       | Boolean | Return results in binary format |
+| descending   | Boolean | Reverse chronological order |
+| limit        | Integer | Max results per page (defaults to 20). Cannot be more than 1,000. |
+| marker       | String  | [Pagination](#pagination) key from previously returned response |
+| format       | String  | Format of returned results: `csv`,`json` defaults to `json` |
+
 
 #### Response Format ####
 
@@ -1835,25 +2385,116 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count  | Integer | The number of objects contained in the `transactions` field. |
-| marker | String | Pagination marker |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
 | transactions | Array of [transaction objects](#transaction-objects) | All transactions matching the request. |
 
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/transactions?type=Payment&result=tesSUCCESS&limit=1
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 1,
+  "marker": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn|20140602224750|000006979192|00001",
+  "transactions": [
+    {
+      "hash": "074415C5DC6DB0029E815EA6FC2629FBC29A2C9D479F5D040AFF94ED58ECC820",
+      "date": "2014-05-29T17:05:20+00:00",
+      "ledger_index": 6902264,
+      "tx": {
+        "TransactionType": "Payment",
+        "Flags": 0,
+        "Sequence": 1,
+        "LastLedgerSequence": 6902266,
+        "Amount": "100000000",
+        "Fee": "12",
+        "SigningPubKey": "032ECFCC409F02057D8556988B89E17D48ECFC8373965036C6BA294AA2B7972971",
+        "TxnSignature": "30450221008D8E251DA5EA17A29CC9192717860F3B4047E74DF005127A65D9140CAE870C0902201C8E4548D2D3BA11B3E13CE8A167EBC076920E2B1C38547275CAA75FEC436EB9",
+        "Account": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+        "Destination": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+      },
+      "meta": {
+        "TransactionIndex": 1,
+        "AffectedNodes": [
+          {
+            "CreatedNode": {
+              "LedgerEntryType": "AccountRoot",
+              "LedgerIndex": "13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8",
+              "NewFields": {
+                "Sequence": 1,
+                "Balance": "100000000",
+                "Account": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn"
+              }
+            }
+          },
+          {
+            "ModifiedNode": {
+              "LedgerEntryType": "AccountRoot",
+              "PreviousTxnLgrSeq": 6486567,
+              "PreviousTxnID": "FF9BFF3C200B475CA7EE54F9A98EAB7E92BBDBD2DBE95AC854405D8A85C9D535",
+              "LedgerIndex": "43EA78783A089B137D5E87610DF3BD4129F989EDD02EFAF6C265924D3A0EF8CE",
+              "PreviousFields": {
+                "Sequence": 1,
+                "Balance": "1000000000"
+              },
+              "FinalFields": {
+                "Flags": 0,
+                "Sequence": 2,
+                "OwnerCount": 0,
+                "Balance": "899999988",
+                "Account": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX"
+              }
+            }
+          }
+        ],
+        "TransactionResult": "tesSUCCESS"
+      }
+    }
+  ]
+}
+```
 
 
 
-## Get Transactions By Account And Sequence V2 ##
+
+## Get Transaction By Account And Sequence ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountTxSeq.js "Source")
 
 Retrieve a specifc transaction originating from a specified account
+
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
 
 ```
 GET /v2/accounts/{:address}/transactions/{:sequence}
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
-  * :sequence (integer)...transaction sequence
-  * binary (boolean)..return transaction in binary format
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field     | Value   | Description |
+|-----------|---------|-------------|
+| :address  | String  | Ripple address to query |
+| :sequence | Integer | Transaction sequence |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field  | Value   | Description |
+|--------|---------|-------------|
+| binary | Boolean | Return transaction in binary format |
+
 
 #### Response Format ####
 
@@ -1864,6 +2505,28 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | result | `success` | Indicates that the body represents a successful response. |
 | transaction | [transaction object](#transaction-objects) | requested transaction |
 
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/transactions/10?binary=true
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "transaction": {
+    "hash": "4BFFBB86C12659B6C5BB88F0EB859356DE3433EBACBFD9F50F6E70B2C05CCFE0",
+    "date": "2014-09-15T19:59:10+00:00",
+    "ledger_index": 8889812,
+    "tx": "1200052200000000240000000A68400000000000000A732103AB40A0490F9B7ED8DF29D246BF2D6269820A0EE7742ACDD457BEA7C7D0931EDB74473045022100AA4AF08726FCF0F28AA4A841C45F975C3BF1545648F6907DCB33F6E3DD7E85D6022037365B80AB1972BF8A4280009A0DBCF16A1D562ED0489B155750E48CC939039981144B4E9C06F24296074F7BC48F92A97916C6DC5EA9",
+    "meta": "201C00000003F8E5110061250087A5C555CBCA96F4C42E0EBC0E75C5AD84B3403FEDF824A7DAFA45ADCA6ECB66AA143C1B5613F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8E6240000000A62400000000DB5852F8814D3484B9ED2556DCE16A3B928B438BA6EE0FF0989E1E72200010000240000000B2D0000000062400000000DB5852572110000000000000000000000070000000300770A6D64756F31332E636F6D81144B4E9C06F24296074F7BC48F92A97916C6DC5EA9E1E1F1031000"
+  }
+}
+```
 
 
 
@@ -1872,21 +2535,39 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 Retrieve a payments for a specified account
 
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
+
 ```
 GET /v2/accounts/{:address}/payments
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * type (string)...type of payment - 'sent' or 'received'
-  * currency(string)...restrict results to specified currency
-  * issuer(string)...restrict results to specified issuer
-  * descending (boolean)...reverse cronological order
-  * limit (integer)...max results per page (defaults to 20)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :address | String | Ripple address to query |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| start      | String - [Timestamp][]  | Start time of query range |
+| end        | String - [Timestamp][]  | End time of query range |
+| type       | String  | Type of payment - `sent` or `received` |
+| currency   | String  | Restrict results to specified currency |
+| issuer     | String  | Restrict results to specified issuer |
+| descending | Boolean | Reverse chronological order |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1,000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response |
+| format     | String  | Format of returned results: `csv`,`json` defaults to `json` |
+
 
 #### Response Format ####
 
@@ -1896,8 +2577,55 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count  | Integer | The number of objects contained in the `payments` field. |
-| marker | String | Pagination marker |
-| payments | Array of payment objects | All payments matching the request. |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
+| payments | Array of [payment objects][] | All payments matching the request. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/payments?currency=USD&limit=1
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 1,
+  "marker": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn|20140604191650|000007013674|00000",
+  "payments": [
+    {
+      "amount": "1.0",
+      "delivered_amount": "1.0",
+      "destination_balance_changes": [
+        {
+          "counterparty": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+          "currency": "USD",
+          "value": "1"
+        }
+      ],
+      "transaction_cost": "1.0E-5",
+      "source_balance_changes": [
+        {
+          "counterparty": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+          "currency": "USD",
+          "value": "-1"
+        }
+      ],
+      "currency": "USD",
+      "destination": "ra5nK24KXen9AHvsdFTKHSANinZseWnPcX",
+      "executed_time": "2014-06-02T22:47:50",
+      "issuer": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "ledger_index": 6979192,
+      "source": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn",
+      "source_currency": "USD",
+      "tx_hash": "7BF105CFE4EFE78ADB63FE4E03A851440551FE189FD4B51CAAD9279C9F534F0E"
+    }
+  ]
+}
+```
 
 
 
@@ -1907,21 +2635,46 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 Retrieve Exchanges for a given account over time.
 
+#### Request Format ####
+
+There are two variations on this method:
+
+<!--<div class='multicode'>-->
+
+*REST - All Exchanges*
+
 ```
-GET /v2/account/{:address}/exchanges/
-GET /v2/account/{:address}/exchanges/{:base}/{:counter}
+GET /v2/accounts/{:address}/exchanges/
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
-  * :base(string)...base currency of the pair in the format currency[+issuer]
-  * :counter(string)...counter currency of the pair in the format currency[+issuer]
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * descending (boolean)...reverse cronological order
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+*REST - Specific Currency Pair*
+
+```
+GET /v2/accounts/{:address}/exchanges/{:base}/{:counter}
+```
+
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :address | String | Ripple address to query |
+| :base    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+| :counter | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| start      | String - [Timestamp][]  | Start time of query range |
+| end        | String - [Timestamp][]  | End time of query range |
+| descending | Boolean | Reverse chronological order |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response |
+| format     | String  | Format of returned results: `csv`,`json` defaults to `json` |
+
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1930,8 +2683,67 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of exchanges returned. |
-| marker | String | Pagination marker |
-| exchanges | Array of exchange objects | The requested exchanges |
+| marker | String | (May be omitted) [Pagination](#pagination) marker |
+| exchanges | Array of [Exchange Objects][] | The requested exchanges |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rsyDrDi9Emy6vPU78qdxovmNpmj5Qh4NKw/exchanges/KRW+rUkMKjQitpgAM5WTGk79xpjT38DEJY283d/XRP?start=2015-08-08T00:00:00Z&end=2015-08-31T00:00:00Z&limit=2
+
+```
+
+Response:
+
+```
+{
+    "result": "success",
+    "count": 2,
+    "marker": "rsyDrDi9Emy6vPU78qdxovmNpmj5Qh4NKw|20150810014200|000015162386|00013|00003",
+    "exchanges": [
+        {
+            "base_amount": 209.3501241148,
+            "counter_amount": 20.424402,
+            "rate": 0.097560973925,
+            "autobridged_currency": "USD",
+            "autobridged_issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+            "base_currency": "KRW",
+            "base_issuer": "rUkMKjQitpgAM5WTGk79xpjT38DEJY283d",
+            "buyer": "rnAqwsu2BEbCjacoZmsXrpViqd3miZhHbT",
+            "counter_currency": "XRP",
+            "executed_time": "2015-08-08T02:57:40",
+            "ledger_index": 15122851,
+            "offer_sequence": "1738",
+            "provider": "rsyDrDi9Emy6vPU78qdxovmNpmj5Qh4NKw",
+            "seller": "rsyDrDi9Emy6vPU78qdxovmNpmj5Qh4NKw",
+            "taker": "rnAqwsu2BEbCjacoZmsXrpViqd3miZhHbT",
+            "tx_hash": "506D109A609A5E0778276CCBB125A4AA7B78428059F069A2CB4F739B861C0C49",
+            "tx_type": "OfferCreate"
+        },
+        {
+            "base_amount": 86355.6498758851,
+            "counter_amount": 8424.941452,
+            "rate": 0.097560975618,
+            "base_currency": "KRW",
+            "base_issuer": "rUkMKjQitpgAM5WTGk79xpjT38DEJY283d",
+            "buyer": "r9xQi5YT8jqVM3wZhbiV94ZKKvGHaVeSDj",
+            "client": "rt1.1-26-gbeb68ab",
+            "counter_currency": "XRP",
+            "executed_time": "2015-08-08T07:15:00",
+            "ledger_index": 15126536,
+            "offer_sequence": "1738",
+            "provider": "rsyDrDi9Emy6vPU78qdxovmNpmj5Qh4NKw",
+            "seller": "rsyDrDi9Emy6vPU78qdxovmNpmj5Qh4NKw",
+            "taker": "r9xQi5YT8jqVM3wZhbiV94ZKKvGHaVeSDj",
+            "tx_hash": "C897A595DED16ADF5AD52E6FD9CE5DE65C78A93CCAA62A85248DC3015A78F5C4",
+            "tx_type": "Payment"
+        }
+    ]
+}
+```
+
 
 
 
@@ -1940,20 +2752,38 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 
 Retrieve Balance changes for a given account over time.
 
+#### Request Format ####
+
+<!--<div class='multicode'>-->
+
+*REST*
+
 ```
-GET /v2/account/{:address}/balance_changes/
+GET /v2/accounts/{:address}/balance_changes/
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
-  * currency(string)...restrict results to specified currency
-  * issuer(string)...restrict results to specified counterparty/issuer
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * descending (boolean)...reverse cronological order
-  * limit (integer)...max results per page (defaults to 200)
-  * marker (string)...pagination key from previously returned response
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :address | String | Ripple address to query |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| currency   | String  | Restrict results to specified currency. |
+| issuer     | String  | Restrict results to specified counterparty/issuer. |
+| start      | String - [Timestamp][]  | Start time of query range. |
+| end        | String - [Timestamp][]  | End time of query range. |
+| descending | Boolean | If true, return results in reverse chronological order. Defaults to false. |
+| limit      | Integer | Max results per page (defaults to 200). Cannot be more than 1000. |
+| marker     | String  | [Pagination](#pagination) key from previously returned response. |
+| format     | String  | Format of returned results: `csv` or`json`. Defaults to `json`. |
+
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1962,8 +2792,61 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
 | count | Integer | Number of balance changes returned. |
-| marker | String | Pagination marker |
-| exchanges | Array of balance change objects | The requested balance changes |
+| marker | String | (May be omitted) [Pagination](#pagination) marker. |
+| exchanges | Array of [balance change descriptors][] | The requested balance changes. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn/balance_changes?descending=true&limit=3
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 3,
+  "marker": "rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn|20150616212230|000014091020|00003|$",
+  "balance_changes": [
+    {
+      "change": "-0.012",
+      "final_balance": "148.446663",
+      "tx_index": 1,
+      "change_type": "transaction_cost",
+      "currency": "XRP",
+      "executed_time": "2015-06-16T21:32:40",
+      "ledger_index": 14091160,
+      "tx_hash": "0D5FB50FA65C9FE1538FD7E398FFFE9D1908DFA4576D8D7A020040686F93C77D",
+      "node_index": null
+    },
+    {
+      "change": "-0.012",
+      "final_balance": "148.458663",
+      "tx_index": 20,
+      "change_type": "transaction_cost",
+      "currency": "XRP",
+      "executed_time": "2015-06-16T21:22:40",
+      "ledger_index": 14091022,
+      "tx_hash": "26C1C876D709380DF7136F307B84E7F16CD74381F82E9B2D352A92069C880D66",
+      "node_index": null
+    },
+    {
+      "change": "-30.0",
+      "final_balance": "148.470663",
+      "node_index": 0,
+      "tx_index": 3,
+      "change_type": "payment_source",
+      "currency": "XRP",
+      "executed_time": "2015-06-16T21:22:30",
+      "ledger_index": 14091020,
+      "tx_hash": "73699F26E2A4A8703EB48684FF38CD6362B7ABF217576AB460CBAA64D383D9EC"
+    }
+  ]
+}
+```
 
 
 
@@ -1971,22 +2854,43 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 ## Get Account Reports ##
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routesV2/accountReports.js "Source")
 
-Retrieve Daily summaries of payment activity for an account.
+Retrieve daily summaries of payment activity for an account.
+
+<!--<div class='multicode'>-->
+
+*REST - Date Omitted*
 
 ```
-GET /v2/account/{:address}/reports/
-GET /v2/account/{:address}/reports/{:date}
+GET /v2/accounts/{:address}/reports/
 ```
 
-#### Params ####
-  * :address (string)...ripple address to query
-  * :date (string)...UTC date for single report
-  * start (string)...UTC start time of query range
-  * end (string)...UTC end time of query range
-  * accounts (boolean)...include lists of counterparty accounts
-  * payments (boolean)...include lists of individual payments
-  * descending (boolean)...reverse cronological order
-  * format (string)...format of returned results: 'csv','json' defaults to 'json'
+*REST - Date Specified*
+
+```
+GET /v2/accounts/{:address}/reports/{:date}
+```
+
+<!--</div>-->
+
+This method requires the following URL parameters:
+
+| Field    | Value  | Description |
+|----------|--------|-------------|
+| :address | String | Ripple address to query |
+| :date    | String | (Optional) UTC date for single report. If omitted, use the `start` and `end` query parameters. |
+
+
+Optionally, you can also include the following query parameters:
+
+| Field      | Value   | Description |
+|------------|---------|-------------|
+| start      | String  | UTC start time of query range. Defaults to start of current date. Ignored if `date` specified. |
+| end        | String  | UTC end time of query range. Defaults to current date. Ignored if `date` specified. |
+| accounts   | Boolean | If true, provide lists with addresses of all `sending_counterparties` and `receiving_counterparties` in results. Otherwise, return only the number of sending and receiving counterparties. |
+| payments   | Boolean | Include [Payment Summary Objects][] in the `payments` field for each interval, with the payments that occurred during that interval. |
+| descending | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
+| format     | String  | Format of returned results: `csv`,`json` defaults to `json` |
+
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
@@ -1994,46 +2898,416 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | Field  | Value | Description |
 |--------|-------|-------------|
 | result | `success` | Indicates that the body represents a successful response. |
-| start | String | Start of range for reports returned |
-| end | String | End of range for reports returned |
-| count | Integer | Number of reports returned |
-| reports | Array of report objects | The requested reports |
+| count | Integer | Number of reports returned. |
+| reports | Array of [Reports Objects][] | Daily summaries of account activity for the given account and date range. |
+
+#### Example ####
+
+Request:
+
+```
+GET /v2/accounts/rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q/reports?start=2015-08-28T00:00:00&end=2015-08-28T00:00:00&accounts=true&payments=true&descending=true
+```
+
+Response:
+
+```
+{
+  "result": "success",
+  "count": 1,
+  "reports": [
+    {
+      "account": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+      "date": "2015-08-28T00:00:00+00:00",
+      "high_value_received": 89500.74142547617,
+      "high_value_sent": 0,
+      "payments": [
+        {
+          "tx_hash": "F2323EE7494384E77ABB18F31981FEE8C31767BBD27515B55FC3BD6792C4E408",
+          "amount": 2.7,
+          "currency": "BTC",
+          "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+          "type": "received"
+        },
+        {
+          "tx_hash": "FEAD462738EE430E154FF3122D3EE2DD27DDD8BEFBA080A60FE91B78E8865365",
+          "amount": 3,
+          "currency": "BTC",
+          "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+          "type": "received"
+        },
+        {
+          "tx_hash": "383B1D1EABB646AB2EFBBF9E8967FE279BFE5EF86A3B6BCD5BDA287210053116",
+          "amount": 0.14,
+          "currency": "BTC",
+          "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+          "type": "received"
+        }
+      ],
+      "payments_received": 3,
+      "payments_sent": 0,
+      "receiving_counterparties": [],
+      "sending_counterparties": [
+        "rhi4zZdCeFdfTokzek8D7p9bUWmtEFCZAe",
+        "rP1hkW1LCiVos6FpzU7itmm9Tk29yqvyk5"
+      ],
+      "total_value": 174019.58324753598,
+      "total_value_received": 174019.58324753598,
+      "total_value_sent": 0
+    }
+  ]
+}
+```
+
+
+# API Conventions #
+
+## Basic Types ##
+
+As a REST API, the Data API v2 uses [JSON](http://json.org/)'s native datatypes to represent API fields, with some special cases.
+
+### Numbers and Precision ###
+[String - Number]: #numbers-and-precision
+
+Currency amounts in Ripple require more precision than most native number types, so the Data API v2 uses the String type to represent some values.
+
+Within the String value, the numbers are serialized in the same way as native JSON numbers:
+
+* Base-10.
+* Non-zero-prefaced.
+* May contain `.` as a decimal point. For example, ½ is represented as `0.5`. (American style, not European)
+* May contain `E` or `e` to indicate being raised to a power of 10. For example, `1.2E5` is equivalent to `120000`.
+* No comma (`,`) characters are used.
+
+The precision for amounts of **non-XRP currency** in Ripple is as follows:
+
+* Minimum nonzero absolute value: `1000000000000000e-96`
+* Maximum value: `9999999999999999e80`
+* Minimum value: `-9999999999999999e80`
+* 15 decimal digits of precision
+
+**XRP** has a different internal representation, and consequently its precision is different:
+
+* Minimum value: `0`
+* Maximum value: `100000000000` (`1e11`)
+* Precise to the nearest `0.000001` (`1e-6`)
+
+In other words, XRP has the same precision as a 64-bit unsigned integer where each unit is equivalent to 0.000001 XRP.
+
+### Addresses ###
+[Address]: #addresses
+
+Ripple Accounts are identified by a base-58 Ripple Address, which is derived from the account's master public key. An address is represented as a String in JSON, with the following characteristics:
+
+* Between 25 and 35 characters in length
+* Starts with the character `r`
+* Case-sensitive
+* Base-58 encoded using only the following characters: `rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz` That's alphanumeric characters, excluding zero (`0`), capital O (`O`), capital I (`I`), and lowercase L (`l`).
+* Contains error-checking that makes it unlikely that a randomly-generated string is a valid address.
+
+### Hashes ###
+[Hash]: #hashes
+
+Many objects in Ripple, particularly transactions and ledgers, are uniquely identified by a 256-bit hash value. This value is typically calculated as a "SHA-512Half", which calculates a SHA-512 hash from some contents, then takes the first 64 characters of the hexadecimal representation. Since the hash of an object is derived from the contents in a way that is extremely unlikely to produce collisions, two objects with the same hash can be considered identical.
+
+A Ripple hash value has the following characteristics:
+
+* Exactly 64 characters in length
+* [Hexadecimal](https://en.wikipedia.org/wiki/Hexadecimal) character set: 0-9 and A-F.
+* Typically written in upper case.
+
+**Note:** SHA-512Half has similar security to the officially-defined _SHA-512/256_ hash function. However, Ripple's usage predates SHA-512/256 and is also easier to implement on top of an existing SHA-512 function (since support for SHA-512/256 is not common in cryptographic libraries as of this writing).
+
+
+### Timestamps ###
+[Timestamp]: #timestamps
+
+All dates and times are written in ISO 8601 Timestamp Format, using UTC. This format is summarized as:
+
+`YYYY-MM-DDThh:mm:ssZ`
+
+* Four-digit year
+* Two-digit month
+* Two-digit day
+* The letter `T` indicating the beginning of the time portion
+* Two-digit hour using a 24-hour clock
+* Two digit minute
+* The letter `Z` indicating zero offset from UTC.
+
+(As of [v2.0.4][], the offset `+00:00` is no longer used.)
+
+### Ledger Index ###
+[Ledger Index]: #ledger-index
+
+A ledger index is a 32-bit unsigned integer used to identify a ledger. The ledger index is also known as the ledger's sequence number. The very first ledger was ledger index 1, and each subsequent ledger has a ledger index 1 higher than that of the ledger immediately before it.
+
+Two ledgers with the same ledger index are guaranteed to have identical contents _if they are validated by consensus_. Ledgers that are not validated by consensus may have different contents even with the same ledger index. (The [Hash][] values of two ledgers can tell you whether those ledgers have the exact same contents.)
+
+### Account Sequence ###
+[Sequence Number]: #account-sequence
+
+A Sequence number is a 32-bit unsigned integer used to identify a transaction or Offer relative to a specific account.
+
+Every [account object in the Ripple Consensus Ledger](https://ripple.com/build/ledger-format/#accountroot) has a Sequence number, which starts at 1. For a transaction to be relayed to the network and possibly included in a validated ledger, it must have a `Sequence` field that matches the sending account's current `Sequence` number. An account's Sequence field is incremented whenever a transaction from that account is included in a validated ledger (regardless of whether the transaction succeeded or failed). This preserves the order of transactions submitted by an account, and differentiates transactions that would otherwise be identical.
+
+Every [Offer node in the Ripple Consensus Ledger](https://ripple.com/build/ledger-format/#offer) is marked with the sending `Account` [Address][] and the `Sequence` value of the [OfferCreate transaction](https://ripple.com/build/transactions/#offercreate) that created it. These two fields, together, uniquely identify the Offer.
+
+### Currency Code ###
+[Currency Code]: #currency-code
+
+Currencies in Ripple can be represented in two ways:
+
+* As three-letter [ISO 4217 Currency Codes](http://www.xe.com/iso4217.php). These currency codes must be written in uppercase ("USD" is valid, "usd" is not). Ripple permits currency codes that are not officially approved, including currency codes with digits in them.
+* As 160-bit hexadecimal values, such as `0158415500000000C1F76FF6ECB0BAC600000000`, according to Ripple's internal [Currency Format](https://wiki.ripple.com/Currency_format). This representation is uncommon.
+
+## Pagination ##
+
+Many queries may return more data than is reasonable to return in a single HTTP response. The Data API uses a "limit and marker" system to control how much is returned in a single response ("page") and to query for additional content.
+
+The `limit` query parameter to many requests restricts the response to a specific number of results in the response. The types of results and default values vary based on the method. For most methods, the `limit` is **200** by default, and can be set as high as **1000**. If you specify a `limit` larger than the maximum, the API uses the maximum value instead.
+
+When a query has additional objects that are not contained in the current response, the JSON response contains a top-level field `marker` which indicates that you can retrieve additional results by including the contents of the `marker` field as the `marker` query parameter of a subsequent request. For the follow-up request, you should use the same parameters as the initial request. When the response omits the `marker` parameter, that indicates that you have reached the end of the queryable data.
+
+When a `marker` is or would be present, the response contains a [`Link` header](https://tools.ietf.org/html/rfc5988#section-5) with `rel="next"`. This is a full URL to the next page of results. You can use this to paginate over results when the response is in `csv` format instead of `json`. _(New in [v2.0.4][])_
+
+## Transaction Objects ##
+
+Transactions have two formats - a compact "binary" format where the defining fields of the transaction are encoded as strings of hex, and an expanded format where the defining fields of the transaction are nested as complete JSON objects.
+
+### Full JSON Format ###
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| hash  | String - [Hash][] | An identifying hash value unique to this transaction, as a hex string. |
+| date  | String - [Timestamp][] | The time when this transaction was included in a validated ledger. |
+| ledger_index | Number - [Ledger Index][] | The sequence number of the ledger that included this ledger. |
+| tx    | Object | The fields of this transaction object, as defined by the [Transaction Format](https://ripple.com/build/transactions) |
+| meta  | Object | Metadata about the results of this transaction. |
+
+### Binary Format ###
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| hash  | String - [Hash][] | An identifying hash value unique to this transaction, as a hex string. |
+| date  | String - [Timestamp][] | The time when this transaction was included in a validated ledger. |
+| ledger_index | Number - [Ledger Index][] | The sequence number of the ledger that included this ledger. |
+| tx    | String | The binary data that represents this transaction, as a hexadecimal string. |
+| meta  | String | The binary data that represents this transaction's metadata, as a hex string. |
+
+## Ledger Objects ##
+
+A "ledger" is one version of the shared global ledger. Each ledger object has the following fields:
+
+| Field        | Value | Description |
+|--------------|-------|-------------|
+| ledger\_hash  | String - [Hash][] | An identifying hash unique to this ledger, as a hex string. |
+| ledger\_index | Number - [Ledger Index][] | The sequence number of the ledger. Each new ledger has a ledger index 1 higher than the ledger that came before it. |
+| parent\_hash  | String - [Hash][] | The identifying hash of the previous ledger. |
+| total\_coins  | [String - Number][] | The total number of "drops" of XRP still in existence at the time of the ledger. (Each XRP is 1,000,000 drops.) |
+| close\_time\_res | Number | The ledger close time is rounded to approximately this many seconds. |
+| accounts\_hash | String - [Hash][] | Hash of the account information contained in this ledger, as hex. |
+| transactions\_hash | String - [Hash][] | Hash of the transaction information contained in this ledger, as hex. |
+| close\_time | Number | The time at which this ledger was closed, in UNIX time. |
+| close\_time\_human | String - [Timestamp][] | The time at which this ledger was closed. |
+
+**Note:** Ledger close times are approximate, typically rounded to about 10 seconds. Consequently, two subsequent ledgers could have the same close time recorded, when actual close times were several seconds apart. The sequence number (`ledger_index`) of the ledger makes it unambiguous which ledger closed first.
+
+### Genesis Ledger ###
+
+Due to a mishap early in Ripple's history, ledgers 1 through 32569 were lost. Thus, ledger #32570 is the earliest ledger available anywhere. For purposes of the Data API v2, ledger #32570 is considered the _genesis ledger_.
+
+## Account Creation Objects ##
+
+An account creation object represents the action of creating an account in the Ripple Consensus Ledger. There are two variations, depending on whether the account was already present in ledger 32570, the earliest ledger available. Accounts that were already present in ledger 32570 are termed _genesis accounts_.
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| address | String - [Address][] | The identifying address of this account, in base-58. |
+| inception | String - [Timestamp][] | The UTC timestamp that the account was created. For genesis accounts, this is the timestamp of ledger 32570. |
+| ledger\_index | Number - [Ledger Index][] | The sequence number of the ledger when the account was created, or 32570 for genesis accounts. |
+| parent | String - [Address][] | (Omitted for genesis accounts) The identifying address of the account that provided the initial funding for this account. |
+| tx\_hash | String - [Hash][] | (Omitted for genesis accounts) The identifying hash of the transaction that funded this account. |
+| initial\_balance | [String - Number][] | (Omitted for genesis accounts) The amount of XRP that funded this account. |
+| genesis\_balance | [String - Number][] | (Genesis accounts only) The amount of XRP this account held as of ledger #32570. |
+| genesis\_index | Number - [Sequence Number][] | (Genesis accounts only) The transaction sequence number of the account as of ledger #32570. |
+
+
+## Exchange Objects ##
+[Exchange Objects]: #exchange-objects
+
+An exchange object represents an actual exchange of currency, which can occur in the Ripple Consensus Ledger as the result of executing either an OfferCreate transaction or a Payment transaction. In order for currency to actually change hands, there must be a previously-unfilled Offer previously placed in the ledger with an OfferCreate transaction.
+
+A single transaction can cause several exchanges to occur. In this case, the sender of the transaction is the taker for all the exchanges, but each exchange will have a different provider, currency pair, or both.
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| base\_amount | Number | The amount of the base currency that was traded |
+| counter\_amount | Number | The amount of the counter currency that was traded |
+| rate | Number | The amount of the counter currency acquired per 1 unit of the base currency |
+| autobridged\_currency | String - [Currency Code][] | (May be omitted) If the offer was autobridged (XRP order books were used to bridge two non-XRP currencies), this is the other currency from the offer that executed this exchange. |
+| autobridged\_issuer | String - [Address][] | (May be omitted) If the offer was autobridged (XRP order books were used to bridge two non-XRP currencies), this is the other currency from the offer that executed this exchange. |
+| base\_currency | String - [Currency Code][] | The base currency |
+| base\_issuer | String - [Address][] | (Omitted for XRP) The account that issued the base currency |
+| buyer | String - [Address][] | The account that acquired the base currency |
+| client | String | (May be omitted) If the transaction contains a memo indicating what client application sent it, this is the contents of the memo. |
+| counter\_currency | String - [Currency Code][] | The counter currency |
+| counter\_issuer | String - [Address][] | (Omitted for XRP) The account that issued the counter currency |
+| executed\_time | String - [Timestamp][] | The time the exchange occurred |
+| ledger\_index | Number - [Ledger Index][] | The sequence number of the ledger that included this transaction |
+| offer\_sequence | Number - [Sequence Number][] | The sequence number of the `provider`'s existing offer in the ledger. |
+| provider | String - [Address][] | The account that had an existing Offer in the ledger |
+| seller | String - [Address][] | The account that acquired the counter currency |
+| taker | String - [Address][] | The account that sent the transaction which executed this exchange |
+| tx\_hash | String - [Hash][] | The identifying hash of the transaction that executed this exchange. (**Note:** This exchange may be one of several executed in a single transaction.) |
+| tx\_type | String | The type of transaction that executed this exchange, either `Payment` or `OfferCreate`. |
+
+
+## Reports Objects ##
+[Reports Objects]: #reports-objects
+
+Reports objects show the activity of a given account over a specific interval of time, typically a day. Reports have the following fields:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| account | String - [Address][] | The address of the account to which this report pertains. |
+| date | String - [Timestamp][] | The start of the interval to which this report pertains. |
+| high\_value\_received | [String - Number][] | Largest amount received in a single transaction, normalized to XRP (as closely as possible). This includes payments and exchanges. |
+| high\_value\_sent | [String - Number][] | The largest amount sent in a single transaction, normalized to XRP (as closely as possible). |
+| payments | Array of [Payment Summary Objects][] | (May be omitted) Array with information on each payment sent or received by the account during this interval. |
+| payments\_received | Number | The number of payments sent to this account. (This only includes payments for which this account was the destination, not payments that only rippled through the account or consumed the account's offers.) |
+| payments\_sent | Number | The number of payments sent by this account. |
+| receiving\_counterparties | Array or Number | If account lists requested, an array of addresses that received payments from this account. Otherwise, the number of different accounts that received payments from this account. |
+| sending\_counterparties | Array or Number |  If account lists requested, an array of addresses that sent payments to this account. Otherwise, the number of different accounts that sent payments to this account. |
+| total\_value | [String - Number][] | Sum of total value received and sent in payments, normalized to XRP (as closely as possible). |
+| total\_value\_received | [String - Number][] | Sum value of all payments to this account, normalized to XRP (as closely as possible). |
+| total\_value\_sent | [String - Number][] | Sum value of all payments from this account, normalized to XRP (as closely as possible).
+
+## Payment Summary Objects ##
+[Payment Summary Objects]: #payment-summary-objects
+
+A Payment Summary Object contains a reduced amount of information about a single payment from the perspective of either the sender or receiver of that payment. 
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| tx\_hash | String - [Hash][] | The identifying hash of the transaction that caused the payment. |
+| delivered\_amount | [String - Number][] | The amount of the destination `currency` actually received by the destination account. |
+| currency | String - [Currency Code][] | The currency delivered to the recipient of the transaction. |
+| issuer | String - [Address][] | The gateway issuing the currency, or an empty string for XRP. |
+| type | String | Either `sent` or `received`, indicating whether the perspective account is sender or receiver of this transaction. |
+
+
+## Payment Objects ##
+[Payment Objects]: #payment-objects
+
+In the Data API, a Payment Object represents an event where one account sent value to another account. This mostly lines up with Ripple transactions of the `Payment` [transaction type](https://ripple.com/build/transactions/), except that the Data API does not consider a transaction to be a payment if the sending `Account` and the `Destination` account are the same, or if the transaction failed.
+
+Payment objects have the following fields:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| amount | [String - Number][] | The amount of the destination `currency` that the transaction was instructed to send. In the case of Partial Payments, this is a "maximum" amount. |
+| delivered\_amount | [String - Number][] | The amount of the destination `currency` actually received by the destination account. |
+| destination\_balance\_changes | Array | Array of [balance change objects][], indicating all changes made to the `destination` account's balances. |
+| source\_balance\_changes | Array | Array of [balance change objects][], indicating all changes to the `source` account's balances (except the XRP transaction cost). |
+| transaction\_cost | [String - Number][] | The amount of XRP spent by the `source` account on the transaction cost. (Prior to [v2.0.4][], this parameter was called `fee`.) |
+| currency | String - [Currency Code][] | The currency that the `destination` account received. |
+| destination | String - [Address][] | The account that received the payment. |
+| executed\_time | String - [Timestamp][] | The time the ledger that included this payment closed. |
+| ledger\_index | Number - [Ledger Index][] | The sequence number of the ledger that included this payment. |
+| source | String - [Address][] | The account that sent the payment. |
+| source\_currency | String - [Currency Code][] | The currency that the `source` account spent. |
+| tx\_hash | String - [Hash][] | The identifying hash of the transaction that caused the payment. |
+
+
+## Balance Objects and Balance Change Objects ##
+[balance change objects]: #balance-objects-and-balance-change-objects
+[Balance Object]: #balance-objects-and-balance-change-objects
+
+Balance objects represent an Ripple account's balance in a specific currency with a specific counterparty at a single point in time. Balance change objects represent a change to such balances that occurs in transaction execution.
+
+A single Ripple transaction may cause changes to balances with several counterparties, as well as changes to XRP.
+
+Balance objects and Balance Change objects have the same format, with the following fields:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| counterparty | String - [Address][] | The counterparty, or issuer, of the `currency`. In the case of XRP, this is an empty string. |
+| currency | String - [Currency Code][] | The currency for which this balance changed. |
+| value | [String - Number][] | The amount of the `currency` that the associated account gained or lost. In balance change objects, this value can be positive (for amounts gained) or negative (for amounts lost). In balance objects, this value can be positive (for amounts the counterparty owes the account) or negative (for amounts owed to the counterparty). |
+
+
+## Balance Change Descriptors ##
+[Balance Change Descriptors]: #balance-change-descriptors
+
+Balance Change Descriptors are objects that describe and analyze a single balance change that occurs in transaction execution. They represent the same events as [balance change objects][], but in greater detail.
+
+Balance Change Descriptors have the following fields:
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| change | [String - Number][] | The difference in the amount of currency held before and after this change. |
+| final\_balance | [String - Number][] | The balance after the change occurred. |
+| node\_index | Number (or `null`)| This balance change is represented by the entry at this index of the ModifiedNodes array within the metadata section of the transaction that executed this balance change. **Note:** When the transaction cost is combined with other changes to XRP balance, the transaction cost has a `node_index` of **null** instead. |
+| tx\_index | Number | The transaction that executed this balance change is at this index in the array of transactions for the ledger that included it. |
+| change\_type | String | One of several [](#change-types) describing what caused this balance change to occur. |
+| currency | String - [Currency Code][] | The change affected this currency. |
+| executed\_time | String - [Timestamp][] | The time the change occurred. (This is based on the close time of the ledger that included the transaction that executed the change. |
+| issuer | String - [Address][] | (Omitted for XRP) The `currency` was issued by this account. |
+| ledger\_index | Number - [Ledger Index][] | The sequence number of the ledger that included the transaction that executed this balance change. |
+| tx\_hash | String - [Hash][] | The identifying hash of the transaction that executed this balance change. |
+
+### Change Types ###
+
+The following values are valid for the `change_type` field of a Balance Change Descriptor:
+
+| Value | Meaning |
+|-------|---------|
+| `transaction_cost` | This balance change reflects XRP that was destroyed to relay a transaction. _(Prior to [v2.0.4][], this was `network fee` instead.)_ |
+| `payment_destination` | This balance change reflects currency that was received from a payment. |
+| `payment_source` | This balance change reflects currency that was spent in a payment. |
+| `exchange` | This balance change reflects currency that was traded for other currency, or the same currency from a different issuer. This can occur in the middle of payment execution as well as from offers. |
+
+## Volume Objects ##
+[Volume Objects]: #volume-objects
+
+Volume objects represent the total volumes of money moved, in either payments or exchanges, during a given time period.
+
+| Field  | Value | Description |
+|--------|-------|-------------|
+| components | Array of Objects | The data that was used to assemble this total. For payment volume, each object represents payments in a particular currency and issuer. For exchange volume, each object represents a market between two currencies. |
+| count | Number | The total number of exchanges in this period. |
+| endTime | String - [Timestamp][] | The end time of this interval. |
+| exchange | Object | Indicates the display currency used, as with fields `currency` and (except for XRP) `issuer`. All amounts are normalized by first converting to XRP, and then to the display currency specified in the request. |
+| exchangeRate | Number | The exchange rate to the displayed currency from XRP. 
+| startTime | String - [Timestamp][] | The start of this time period. |
+| total | Number | Total volume of all recorded exchanges in the time period. |
+
+
 
 
 
 # Running the Historical Database #
 
-You can also run your own instance of the Historical Database software, and populate it with transactions from your own `rippled` instance. This is useful if you do not want to depend on Ripple Labs to operate the historical database indefinitely, or you want access to historical transactions from within your own intranet.
+You can also serve the Data API v2 from your own instance of the Historical Database software, and populate it with transactions from your own `rippled` instance. This is useful if you do not want to depend on Ripple to operate the historical database indefinitely, or you want access to historical transactions from within your own intranet.
 
 ## Installation ##
 
 ### Dependencies ###
 
 The Historical Database requires the following software installed first:
-* [PostgreSQL](http://www.postgresql.org/) (required for v1),
+
 * [HBase](http://hbase.apache.org/) (required for v2),
 * [Node.js](http://nodejs.org/)
 * [npm](https://www.npmjs.org/)
 * [git](http://git-scm.com/) (optional) for installation and updating.
 
+Version 2 of the Historical Database requires HBase instead of [PostgreSQL](http://www.postgresql.org/). Postgres support is deprecated.
+
 ### Installation Process ###
 
-For v1 (postgres):
-  1. Create a new postgres database:
-    `createdb ripple_historical` in PostgreSQL
-  2. Clone the rippled Historical Database Git Repository:
-    `git clone https://github.com/ripple/rippled-historical-database.git`
-    (You can also download and extract a zipped release instead.)
-  3. Use npm to install additional modules:
-    `cd rippled-historical-database`
-    `npm install`
-    The install script will also create the required config files: `config/api.config.json` and `config/import.config.json`
-  4. Modify the API and import config files as needed. If you only wish to run the v1 endpoints, remove the `hbase` section from the api config.
-  5. Load the latest database schema for the rippled Historical Database:
-    `./node_modules/knex/lib/bin/cli.js migrate:latest`
+Starting in 
 
-For v2 (hbase):
-  1. Set up an hbase cluster
+  1. Install HBase. For production use, configure it in distributed mode.
   2. Clone the rippled Historical Database Git Repository:
     `git clone https://github.com/ripple/rippled-historical-database.git`
     (You can also download and extract a zipped release instead.)
@@ -2041,7 +3315,9 @@ For v2 (hbase):
     `cd rippled-historical-database`
     `npm install`
     The install script will also create the required config files: `config/api.config.json` and `config/import.config.json`
-  4. Modify the API and import config files as needed. If you only wish to run the v2 endpoints, remove the `postgres` section from the api config file.
+  4. Modify the API and import config files as needed. Remove the `postgres` section from `api.config.json`.
+
+Reports, stats, and aggregated exchange data needs additional processing before the API can make it available. This processing uses Apache Storm as well as some custom scripts. See [Storm Setup](https://github.com/ripple/rippled-historical-database/blob/develop/storm/README.md) for more information.
 
 At this point, the rippled Historical Database is installed. See [Services](#services) for the different components that you can run.
 
@@ -2050,14 +3326,14 @@ At this point, the rippled Historical Database is installed. See [Services](#ser
 The `rippled` Historical Database consists of several processes that can be run separately.
 
 * [Live Ledger Importer](#live-ledger-importer) - Monitors `rippled` for newly-validated ledgers.
-    `node import/live`
+    Command: `node import/live`
 * [Backfiller](#backfiller) - Populates the database with older ledgers from a `rippled` instance.
-    `node import/postgres/backfill`
-* API Server - Provides [REST API access](#usage) to the data.
-    `npm start` (restarts the server automatically when source files change),
+    Command: `node import/postgres/backfill`
+* API Server - Provides [REST API access](#api-method-reference) to the data.
+    Command:  `npm start` (restarts the server automatically when source files change),
     or `node api/server.js` (simple start)
 
-# Importing Data #
+## Importing Data ##
 
 In order to retrieve data from the `rippled` Historical Database, you must first populate it with data. Broadly speaking, there are two ways this can happen:
 
@@ -2067,28 +3343,22 @@ In order to retrieve data from the `rippled` Historical Database, you must first
 
 In all cases, keep in mind that the integrity of the data is only as good as the original source. If you retrieve data from a public server, you are assuming that the operator of that server is trustworthy. If you load from a database dump, you are assuming that the provider of the dump has not corrupted or tampered with the data.
 
-## Live Ledger Importer ##
+### Live Ledger Importer ###
 
 The Live Ledger Importer is a service that connects to a `rippled` server using the WebSocket API, and listens for ledger close events. Each time a new ledger is closed, the Importer requests the latest validated ledger. Although this process has some fault tolerance built in to prevent ledgers from being skipped, it is still possible that the Importer may miss ledgers.
 
 The Live Ledger Importer includes a secondary process that runs periodically to validate the data already imported and check for gaps in the ledger history.
 
-The Live Ledger Importer can import to one or more different data stores concurrently. If you have configured the historical database to use another storage scheme, you can use the `--type` parameter to specify the database type or types to use. If not specified, the `rippled` Historical Database defaults to PostgreSQL.
+The Live Ledger Importer can import to one or more different data stores concurrently. If you have configured the historical database to use another storage scheme, you can use the `--type` parameter to specify the database type or types to use.
 
-Here are some examples:
+Example usage:
 
 ```
-// defaults to Hbase:
+// start loading records into HBase:
 $ node import/live
-
-// Use Postgres instead:
-$ node import/live --type postgres
-
-// Use PostgreSQL and Hbase simultaneously:
-$ node import/live --type postgres,hbase
 ```
 
-## Backfiller ##
+### Backfiller ###
 
 The Backfiller retrieves old ledgers from a `rippled` instance by moving backwards in time. You can optionally provide start and stop indexes to retrieve a specific range of ledgers, by their sequence number.
 
@@ -2096,15 +3366,12 @@ The `--startIndex` parameter defines the most-recent ledger to retrieve. The Bac
 
 The `--stopIndex` parameter defines the oldest ledger to retrieve. The Backfiller stops after it retrieves this ledger. If omitted, the Backfiller continues as far back as possible. Because backfilling goes from most recent to least recent, the stop index should be a smaller than the start index.
 
-**Warning:** The Backfiller is best for filling in relatively short histories of transactions. Importing a complete history of all Ripple transactions using the Backfiller could take weeks. If you want a full history, we recommend acquiring a database dump with early transctions, and importing it directly. Ripple Labs used the internal SQLite database from an offline `rippled` to populate its historical databases with the early transactions, then used the Backfiller to catch up to date after the import finished.
+**Warning:** The Backfiller is best for filling in relatively short histories of transactions. Importing a complete history of all Ripple transactions using the Backfiller could take weeks. If you want a full history, we recommend acquiring a database dump with early transctions, and importing it directly. Ripple, Inc. used the internal SQLite database from an offline `rippled` to populate its historical databases with the early transactions, then used the Backfiller to catch up to date after the import finished.
 
-Here are some examples:
+Example usage:
 
 ```
-// retrieve everything to PostgreSQL
-node import/postgres/backfill
-
-// get ledgers #1,000,000 to #2,000,000 (inclusive) and store in hbase
+// get ledgers #1,000,000 to #2,000,000 (inclusive) and store in HBase
 node import/hbase/backfill --startIndex 2000000 --stopIndex 1000000
 ```
 


### PR DESCRIPTION
This rewrite of the README is derived directly from the Developer Portal version, which has been reviewed for style and accuracy as of v2.0.4. This update also incorporates edits to remove instructions for the deprecated (Postgres-dependent) version 1 of the software.