### PR TITLE
Fix broken live import + historical backfill

### DIFF
--- a/import/history.js
+++ b/import/history.js
@@ -1,5 +1,5 @@
 var config   = require('../config');
-var Importer = require('../lib/ripple-importer');
+var importer = require('../lib/ripple-importer');
 var Logger   = require('../lib/logger');
 var hbase    = require('../lib/hbase');
 var Parser   = require('../lib/ledgerParser');
@@ -11,11 +11,7 @@ var GENESIS_LEDGER = config.get('genesis_ledger') || 1;
 var EPOCH_OFFSET   = 946684800;
 
 var HistoricalImport = function () {
-  this.importer = new Importer({
-    ripple : config.get('ripple'),
-    logLevel: config.get('logLevel') || 0,
-    logFile: config.get('logFile')
-  });
+  this.importer = importer;
 
   this.count    = 0;
   this.total    = 0;
@@ -31,8 +27,6 @@ var HistoricalImport = function () {
   var self = this;
   var stopIndex;
   var cb;
-
-  hbaseOptions.logLevel = 2;
 
  /**
   * handle ledgers from the importer

--- a/import/live.js
+++ b/import/live.js
@@ -1,14 +1,8 @@
 
 var config = require('../config/import.config');
 var Logger = require('../lib/logger');
-var Importer = require('../lib/ripple-importer');
-var HBase = require('./client');
-var hbase = new HBase();
-
-var live = new Importer({
-  ripple: config.get('ripple'),
-  logLevel: config.get('logLevel')
-});
+var importer = require('../lib/ripple-importer');
+var hbase = require('./client');
 
 var log = new Logger({
   scope: 'live import',
@@ -18,11 +12,11 @@ var log = new Logger({
 
 
 //start import stream
-live.liveStream();
+importer.liveStream();
 
 log.info('Saving Ledgers to HBase');
 
-live.on('ledger', function(ledger) {
+importer.on('ledger', function(ledger) {
   hbase.saveLedger(ledger, function(err, resp) {
     if (err) {
       log.error(err);


### PR DESCRIPTION
b7d8b113364e3dd106e06e7242ee2eb8d4dbadeb caused breaking changes in `node import/live` and `node import/backfill` by updating `client.js` and `ripple-importer.js` to export instances of [`Importer`](https://github.com/ripple/rippled-historical-database/commit/b7d8b113364e3dd106e06e7242ee2eb8d4dbadeb#diff-495796c58b1a84ebe90cf0d8005da6feL433) and [`Client`](https://github.com/ripple/rippled-historical-database/commit/b7d8b113364e3dd106e06e7242ee2eb8d4dbadeb#diff-05c6beebc5e6cbbcb216c3a27a6a83a1R53).