### PR TITLE
Remove unsupported 'descending' param from Get Acct. Payments method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4335,7 +4335,6 @@ Optionally, you can provide the following query parameters:
 | `issuer` | String - [Address][] | Filter results to specified issuer. |
 | `source_tag` | Integer | Filter results to specified source tag. |
 | `destination_tag` | Integer | Filter results to specified destination tag. |
-| `descending` | Boolean | If `true`, sort results with most recent first. Otherwise, return oldest results first. Defaults to `false`. |
 | `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1,000. |
 | `marker` | String  | [Pagination](#pagination) key from previously returned response. |
 | `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
@@ -4350,7 +4349,7 @@ A successful response uses the HTTP code **200 OK** and has a JSON body with the
 | `result` | String | The value `success` indicates that this is a successful response. |
 | `count` | Integer | The number of objects contained in the `payments` field. |
 | `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `payments` | Array of [payment objects][] | All payments matching the request. |
+| `payments` | Array of [payment objects][] | All payments matching the request, sorted with oldest first. |
 
 #### Example
 


### PR DESCRIPTION
Per the conversation archived in [DOC-1195](https://ripplelabs.atlassian.net/browse/DOC-1195), the "Get Account Payments" method does not support `descending: true`.

Let me know if there are any other methods where this is also true.