### PR TITLE
set getPayments limit to 1000 as per official documentation

### DIFF
--- a/api/routes/getPayments.js
+++ b/api/routes/getPayments.js
@@ -105,8 +105,8 @@ function getPayments(req, res) {
   if (isNaN(options.limit)) {
     options.limit = 200
 
-  } else if (options.limit > 200) {
-    options.limit = 200
+  } else if (options.limit > 1000) {
+    options.limit = 1000
   }
 
   hbase.getPayments(options, function(err, resp) {


### PR DESCRIPTION
According to official docs, default limit should be 200 (this is OK), but maximum limit should be 1000 (this is also 200 currently):
https://developers.ripple.com/data-api.html#get-payments