### PR TITLE
Sync README w/ dev portal for Data API v2.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The Ripple Data API v2 replaces the Historical Database v1 and the [Charts API](
 [v2.1.0]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.1.0
 [v2.2.0]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.2.0
 [v2.3.0]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.3.0
+[v2.3.2]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.3.2
+[v2.3.5]: https://github.com/ripple/rippled-historical-database/releases/tag/v2.3.5
 
 
 # API Method Reference
@@ -32,20 +34,18 @@ The Data API v2 provides a REST API with the following methods:
 
 Ledger Contents Methods:
 
-* [Get Ledger - `GET /v2/ledgers/{:ledger_identifier}`](#get-ledger)
-* [Get Transaction - `GET /v2/transactions/{:hash}`](#get-transaction)
+* [Get Ledger - `GET /v2/ledgers/{ledger_identifier}`](#get-ledger)
+* [Get Transaction - `GET /v2/transactions/{hash}`](#get-transaction)
 * [Get Transactions - `GET /v2/transactions/`](#get-transactions)
-* [Get Payments - `GET /v2/payments/{:currency}`](#get-payments)
-* [Get Exchanges - `GET /v2/exchanges/{:base}/{:counter}`](#get-exchanges)
-* [Get Exchange Rates - `GET /v2/exchange_rates/{:base}/{:counter}`](#get-exchange-rates)
+* [Get Payments - `GET /v2/payments/{currency}`](#get-payments)
+* [Get Exchanges - `GET /v2/exchanges/{base}/{counter}`](#get-exchanges)
+* [Get Exchange Rates - `GET /v2/exchange_rates/{base}/{counter}`](#get-exchange-rates)
 * [Normalize - `GET /v2/normalize`](#normalize)
 * [Get Daily Reports - `GET /v2/reports/`](#get-daily-reports)
 * [Get Stats - `GET /v2/stats/`](#get-stats)
-* [Get Capitalization - `GET /v2/capitalization/{:currency}`](#get-capitalization)
-* [Get Active Accounts - `GET /v2/active_accounts/{:base}/{:counter}`](#get-active-accounts)
+* [Get Active Accounts - `GET /v2/active_accounts/{base}/{counter}`](#get-active-accounts)
 * [Get Exchange Volume - `GET /v2/network/exchange_volume`](#get-exchange-volume)
 * [Get Payment Volume - `GET /v2/network/payment_volume`](#get-payment-volume)
-* [Get Issued Value - `GET /v2/network/issued_value`](#get-issued-value)
 * [Get External Markets - `GET /v2/network/external_markets`](#get-external-markets)
 * [Get XRP Distribution - `GET /v2/network/xrp_distribution`](#get-xrp-distribution)
 * [Get Top Currencies - `GET /v2/network/top_currencies`](#get-top-currencies)
@@ -53,42 +53,42 @@ Ledger Contents Methods:
 
 Account Methods:
 
-* [Get Account - `GET /v2/accounts/{:address}`](#get-account)
+* [Get Account - `GET /v2/accounts/{address}`](#get-account)
 * [Get Accounts - `GET /v2/accounts`](#get-accounts)
-* [Get Account Balances - `GET /v2/accounts/{:address}/balances`](#get-account-balances)
-* [Get Account Orders - `GET /v2/accounts/{:address}/orders`](#get-account-orders)
-* [Get Account Transaction History - `GET /v2/accounts/{:address}/transactions`](#get-account-transaction-history)
-* [Get Transaction By Account and Sequence - `GET /v2/accounts/{:address}/transactions/{:sequence}`](#get-transaction-by-account-and-sequence)
-* [Get Account Payments - `GET /v2/accounts/{:address}/payments`](#get-account-payments)
-* [Get Account Exchanges - `GET /v2/accounts/{:address}/exchanges`](#get-account-exchanges)
-* [Get Account Balance Changes - `GET /v2/accounts/{:address}/balance_changes`](#get-account-balance-changes)
-* [Get Account Reports - `GET /v2/accounts/{:address}/reports`](#get-account-reports)
-* [Get Account Transaction Stats - `GET /v2/accounts/{:address}/stats/transactions`](#get-account-transaction-stats)
-* [Get Account Value Stats - `GET /v2/accounts/{:address}/stats/value`](#get-account-value-stats)
+* [Get Account Balances - `GET /v2/accounts/{address}/balances`](#get-account-balances)
+* [Get Account Orders - `GET /v2/accounts/{address}/orders`](#get-account-orders)
+* [Get Account Transaction History - `GET /v2/accounts/{address}/transactions`](#get-account-transaction-history)
+* [Get Transaction By Account and Sequence - `GET /v2/accounts/{address}/transactions/{sequence}`](#get-transaction-by-account-and-sequence)
+* [Get Account Payments - `GET /v2/accounts/{address}/payments`](#get-account-payments)
+* [Get Account Exchanges - `GET /v2/accounts/{address}/exchanges`](#get-account-exchanges)
+* [Get Account Balance Changes - `GET /v2/accounts/{address}/balance_changes`](#get-account-balance-changes)
+* [Get Account Reports - `GET /v2/accounts/{address}/reports`](#get-account-reports)
+* [Get Account Transaction Stats - `GET /v2/accounts/{address}/stats/transactions`](#get-account-transaction-stats)
+* [Get Account Value Stats - `GET /v2/accounts/{address}/stats/value`](#get-account-value-stats)
 
 External Information Methods:
 
 * [Get All Gateways - `GET /v2/gateways`](#get-all-gateways)
-* [Get Gateway - `GET /v2/gateways/{:gateway}`](#get-gateway)
-* [Get Currency Image - `GET /v2/currencies/{:currencyimage}`](#get-currency-image)
+* [Get Gateway - `GET /v2/gateways/{gateway}`](#get-gateway)
+* [Get Currency Image - `GET /v2/currencies/{currencyimage}`](#get-currency-image)
 
 Validation Network Methods:
 
 * [Get Transaction Costs - `GET /v2/network/fees`](#get-transaction-costs)
 * [Get Fee Stats - `GET /v2/network/fee_stats`](#get-fee-stats)
-* [Get Ledger Validations - `GET /v2/ledger/{:hash}/validations`](#get-ledger-validations)
-* [Get Ledger Validation - `GET /v2/ledger/{:hash}/validations/{:pubkey}`](#get-ledger-validation)
+* [Get Ledger Validations - `GET /v2/ledger/{hash}/validations`](#get-ledger-validations)
+* [Get Ledger Validation - `GET /v2/ledger/{hash}/validations/{pubkey}`](#get-ledger-validation)
 * [Get Topology - `GET /v2/network/topology`](#get-topology)
 * [Get Topology Nodes - `GET /v2/network/topology/nodes`](#get-topology-nodes)
-* [Get Topology Node - `GET /v2/network/topology/nodes/{:pubkey}`](#get-topology-node)
+* [Get Topology Node - `GET /v2/network/topology/nodes/{pubkey}`](#get-topology-node)
 * [Get Topology Links - `GET /v2/network/topology/links`](#get-topology-links)
 * [Get Validations  - `GET /v2/network/validations`](#get-validations)
-* [Get Validator  - `GET /v2/network/validators/{:pubkey}`](#get-validator)
+* [Get Validator  - `GET /v2/network/validators/{pubkey}`](#get-validator)
 * [Get Validators  - `GET /v2/network/validators`](#get-validators)
-* [Get Validator Validations - `GET /v2/network/validators/{:pubkey}/validations`](#get-validator-validations)
-* [Get Single Validator Reports - `GET /v2/network/validators/{:pubkey}/reports`](#get-single-validator-reports)
+* [Get Validator Validations - `GET /v2/network/validators/{pubkey}/validations`](#get-validator-validations)
+* [Get Single Validator Reports - `GET /v2/network/validators/{pubkey}/reports`](#get-single-validator-reports)
 * [Get Daily Validator Reports - `GET /v2/network/validator_reports`](#get-daily-validator-reports)
-* [Get rippled Versions - `GET /v2/network/rippled_versions`](#get-rippled-versions)
+* [Get `rippled` Versions - `GET /v2/network/rippled_versions`](#get-rippled-versions)
 
 Health Checks:
 
@@ -110,7 +110,7 @@ Retrieve a specific Ledger by hash, index, date, or latest validated.
 *REST*
 
 ```
-GET /v2/ledgers/{:identifier}
+GET /v2/ledgers/{identifier}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -119,26 +119,26 @@ GET /v2/ledgers/{:identifier}
 
 This method requires the following URL parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `ledger_identifier` | Ledger [Hash][], [Ledger Index][], or [Timestamp][] | (Optional) An identifier for the ledger to retrieve: either the full hash in hex, an integer sequence number, or a date-time. If a date-time is provided, retrieve the ledger that was most recently closed at that time. If omitted, retrieve the latest validated ledger. |
+| Field               | Value                                               | Description |
+|:--------------------|:----------------------------------------------------|:--|
+| `ledger_identifier` | Ledger [Hash][], [Ledger Index][], or [Timestamp][] | _(Optional)_ An identifier for the ledger to retrieve: either the full hash in hex, an integer sequence number, or a date-time. If a date-time is provided, retrieve the ledger that was most recently closed at that time. If omitted, retrieve the latest validated ledger. |
 
 Optionally, you can provide the following query parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
+| Field          | Value   | Description                                       |
+|:---------------|:--------|:--------------------------------------------------|
 | `transactions` | Boolean | If `true`, include the identifying hashes of all transactions that are part of this ledger. |
-| `binary` | Boolean | If `true`, include all transactions from this ledger as hex-formatted binary data. (If provided, overrides `transactions`.) |
-| `expand` | Boolean | If `true`, include all transactions from this ledger as nested JSON objects. (If provided, overrides `binary` and `transactions`.) |
+| `binary`       | Boolean | If `true`, include all transactions from this ledger as hex-formatted binary data. (If provided, overrides `transactions`.) |
+| `expand`       | Boolean | If `true`, include all transactions from this ledger as nested JSON objects. (If provided, overrides `binary` and `transactions`.) |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `ledger` | [Ledger object](#ledger-objects) | The requested ledger. |
+| Field    | Value                            | Description                    |
+|:---------|:---------------------------------|:-------------------------------|
+| `result` | String                           | The value `success` indicates that this is a successful response. |
+| `ledger` | [Ledger object](#ledger-objects) | The requested ledger.          |
 
 #### Example
 
@@ -184,7 +184,7 @@ Retrieve a any validations recorded for a specific ledger hash.  This dataset in
 *REST*
 
 ```
-GET /v2/ledgers/{:ledger_hash}/validations
+GET /v2/ledgers/{ledger_hash}/validations
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -193,28 +193,28 @@ GET /v2/ledgers/{:ledger_hash}/validations
 
 This method requires the following URL parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
+| Field         | Value    | Description                              |
+|:--------------|:---------|:-----------------------------------------|
 | `ledger_hash` | [Hash][] | Ledger hash to retrieve validations for. |
 
 Optionally, you can provide the following query parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `limit`      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker`     | String  | [Pagination](#pagination) key from previously returned response. |
-| `format`     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value   | Description                                             |
+|:---------|:--------|:--------------------------------------------------------|
+| `limit`  | Integer | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
+| `format` | String  | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String - `success` | Indicates that the body represents a successful response. |
-| `ledger_hash` | String - [Hash][] | The identifying hash of the ledger version requested. |
-| `count` | Integer | Number of validations returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
+| Field         | Value                           | Description                |
+|:--------------|:--------------------------------|:---------------------------|
+| `result`      | String - `success`              | Indicates that the body represents a successful response. |
+| `ledger_hash` | String - [Hash][]               | The identifying hash of the ledger version requested. |
+| `count`       | Integer                         | Number of validations returned. |
+| `marker`      | String                          | (May be omitted) [Pagination](#pagination) marker. |
 | `validations` | Array of [Validation Objects][] | All known validation votes for the ledger version. |
 
 
@@ -274,7 +274,7 @@ Retrieve a validation vote recorded for a specific ledger hash by a specific val
 *REST*
 
 ```
-GET /v2/ledgers/{:ledger_hash}/validations/{:pubkey}
+GET /v2/ledgers/{ledger_hash}/validations/{pubkey}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -283,10 +283,10 @@ GET /v2/ledgers/{:ledger_hash}/validations/{:pubkey}
 
 This method requires the following URL parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `ledger_hash` | [Hash][] | Ledger hash to retrieve validations for. |
-| `pubkey` | String - Base-58 [Public Key][] | Validator public key. |
+| Field         | Value                           | Description                |
+|:--------------|:--------------------------------|:---------------------------|
+| `ledger_hash` | [Hash][]                        | Ledger hash to retrieve validations for. |
+| `pubkey`      | String - Base-58 [Public Key][] | Validator public key.      |
 
 This request takes no query parameters.
 
@@ -294,8 +294,8 @@ This request takes no query parameters.
 
 A successful response uses the HTTP code **200 OK** and has a JSON body containing a **[Validation Object][]** with the following additional field:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
+| Field    | Value  | Description                                              |
+|:---------|:-------|:---------------------------------------------------------|
 | `result` | String | The value `success` indicates that this is a successful response. |
 
 #### Example
@@ -336,7 +336,7 @@ Retrieve a specific transaction by its identifying hash.
 *REST*
 
 ```
-GET /v2/transactions/{:hash}
+GET /v2/transactions/{hash}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -345,24 +345,26 @@ GET /v2/transactions/{:hash}
 
 This method requires the following URL parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
+| Field  | Value             | Description                              |
+|:-------|:------------------|:-----------------------------------------|
 | `hash` | String - [Hash][] | The identifying hash of the transaction. |
 
 Optionally, you can provide the following query parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `binary` | Boolean | If `true`, return transaction data in binary format, as a hex string. Otherwise, return transaction data as nested JSON. Defaults to false. |
+| Field    | Value   | Description                                             |
+|:---------|:--------|:--------------------------------------------------------|
+| `binary` | Boolean | If `true`, return transaction data in binary format, as a hex string. Otherwise, return transaction data as nested JSON. The default is `false`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `transaction` | [Transaction object](#transaction-objects) | The requested transaction. |
+| Field         | Value                  | Description                         |
+|:--------------|:-----------------------|:------------------------------------|
+| `result`      | String                 | The value `success` indicates that this is a successful response. |
+| `transaction` | [Transaction object][] | The requested transaction.          |
+
+[Transaction object]: #transaction-objects
 
 #### Example
 
@@ -453,26 +455,28 @@ GET /v2/transactions/
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value | Description |
-|------------|-------|-------------|
-| `start` | String - [Timestamp][]  | Filter results to this time and later. |
-| `end` | String - [Timestamp][]  | Filter results to this time and earlier. |
-| `descending` | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| `type` | String | Filter transactions to a specific [transaction type](https://developers.ripple.com/transaction-types.html). |
-| `result` | String | Filter transactions for a specific [transaction result](https://developers.ripple.com/transaction-results.html). |
-| `binary` | Boolean | If true, return transactions in binary form. Defaults to false. |
-| `limit` | Integer | Maximum results per page. Defaults to 20. Cannot be more than 100. |
-| `marker` | String | [Pagination](#pagination) marker from a previous response. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Filter results to this time and later. |
+| `end`        | String - [Timestamp][] | Filter results to this time and earlier. |
+| `descending` | Boolean                | If `true`, return results in reverse chronological order. The default is `false`. |
+| `type`       | String                 | Filter transactions to a specific [transaction type](https://developers.ripple.com/transaction-types.html). |
+| `result`     | String                 | Filter transactions for a specific [transaction result](https://developers.ripple.com/transaction-results.html). |
+| `binary`     | Boolean                | If `true`, return transactions in binary form. The default is `false`. |
+| `limit`      | Integer                | Maximum results per page. The default is 20. Cannot be more than 100. |
+| `marker`     | String                 | [Pagination](#pagination) marker from a previous response. |
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of Transactions returned. |
-| `marker` | String | (May be omitted) Pagination marker. |
-| `transactions` | Array of [Transaction object](#transaction-objects) | The requested transactions. |
+| Field          | Value                            | Description              |
+|:---------------|:---------------------------------|:-------------------------|
+| `result`       | String                           | The value `success` indicates that this is a successful response. |
+| `count`        | Integer                          | Number of Transactions returned. |
+| `marker`       | String                           | (May be omitted) Pagination marker. |
+| `transactions` | Array of [Transaction objects][] | The requested transactions. |
+
+[Transaction objects]: #transaction-objects
 
 #### Example
 
@@ -609,7 +613,7 @@ GET /v2/payments/
 *REST - Specific Currency*
 
 ```
-GET /v2/payments/{:currency}
+GET /v2/payments/{currency}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -618,32 +622,34 @@ GET /v2/payments/{:currency}
 
 This method uses the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
-| :currency | String | (Optional) Currency code, followed by `+` and a counterparty address. (Or `XRP` with no counterparty.) If omitted, return payments for all currencies. |
+| Field      | Value  | Description                                            |
+|:-----------|:-------|:-------------------------------------------------------|
+| `currency` | String | _(Optional)_ Currency code, followed by `+` and a counterparty address. (Or `XRP` with no counterparty.) If omitted, return payments for all currencies. |
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `start` | String - [Timestamp][]  | Filter results to this time and later. |
-| `end` | String - [Timestamp][]  | Filter results to this time and earlier. |
-| `descending` | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Filter results to this time and later. |
+| `end`        | String - [Timestamp][] | Filter results to this time and earlier. |
+| `descending` | Boolean                | If `true`, return results in reverse chronological order. The default is `false`. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
+The `interval` parameter for aggregated results has been removed as of [v2.3.5][].
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of payments returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `payments` | Array of [Payment Objects][] | The requested payments. |
+| Field      | Value                        | Description                      |
+|:-----------|:-----------------------------|:---------------------------------|
+| `result`   | String                       | The value `success` indicates that this is a successful response. |
+| `count`    | Integer                      | Number of payments returned.     |
+| `marker`   | String                       | (May be omitted) [Pagination](#pagination) marker. |
+| `payments` | Array of [Payment Objects][] | The requested payments.          |
+
 
 #### Example
 
@@ -739,7 +745,7 @@ Retrieve Exchanges for a given currency pair over time.  Results can be returned
 *REST*
 
 ```
-GET /v2/exchanges/{:base}/{:counter}
+GET /v2/exchanges/{base}/{counter}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -748,34 +754,34 @@ GET /v2/exchanges/{:base}/{:counter}
 
 This method requires the following URL parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `base` | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+| Field     | Value  | Description                                             |
+|:----------|:-------|:--------------------------------------------------------|
+| `base`    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
 | `counter` | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
 
 Optionally, you can provide the following query parameters:
 
-| Field       | Value | Description |
-|-------------|-------|-------------|
-| `start` | String - [Timestamp][] | Filter results to this time and later. |
-| `end` | String - [Timestamp][] | Filter results to this time and earlier. |
-| `interval` | String | Aggregation interval: `1minute`, `5minute`, `15minute`, `30minute`, `1hour`, `2hour`, `4hour`, `1day`, `3day`, `7day`, or `1month`. Defaults to non-aggregated results. |
-| `descending` | Boolean | If true, return results in reverse chronological order. |
-| `reduce` | Boolean | Aggregate all individual results. Defaults to false. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 20,000 if `reduce` is true. Otherwise cannot be more than 1,000. |
-| `marker` | String | [Pagination](#pagination) key from previously returned response. |
-| `autobridged` | Boolean | If true, filter results to autobridged exchanges only. |
-| `format` | String | Format of returned results: `csv` or `json`. Defaults to `json` |
+| Field         | Value                  | Description                         |
+|:--------------|:-----------------------|:------------------------------------|
+| `start`       | String - [Timestamp][] | Filter results to this time and later. |
+| `end`         | String - [Timestamp][] | Filter results to this time and earlier. |
+| `interval`    | String                 | Aggregation interval: `1minute`, `5minute`, `15minute`, `30minute`, `1hour`, `2hour`, `4hour`, `1day`, `3day`, `7day`, or `1month`. The default is non-aggregated results. |
+| `descending`  | Boolean                | If `true`, return results in reverse chronological order. |
+| `reduce`      | Boolean                | If `true`, aggregate all individual results. The default is `false`. |
+| `limit`       | Integer                | Maximum results per page. The default is 200. Cannot be more than 20,000 if `reduce` is true. Otherwise cannot be more than 1,000. |
+| `marker`      | String                 | [Pagination](#pagination) key from previously returned response. |
+| `autobridged` | Boolean                | If `true`, filter results to autobridged exchanges only. |
+| `format`      | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of Transactions returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `exchanges` | Array of [Exchange Objects][] | The requested exchanges. |
+| Field       | Value                         | Description                    |
+|:------------|:------------------------------|:-------------------------------|
+| `result`    | String                        | The value `success` indicates that this is a successful response. |
+| `count`     | Integer                       | Number of Transactions returned. |
+| `marker`    | String                        | (May be omitted) [Pagination](#pagination) marker. |
+| `exchanges` | Array of [Exchange Objects][] | The requested exchanges.       |
 
 #### Example
 
@@ -871,7 +877,7 @@ Retrieve an exchange rate for a given currency pair at a specific time.
 *REST*
 
 ```
-GET /v2/exchange_rates/{:base}/{:counter}
+GET /v2/exchange_rates/{base}/{counter}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -880,27 +886,27 @@ GET /v2/exchange_rates/{:base}/{:counter}
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
+| Field     | Value  | Description                                             |
+|:----------|:-------|:--------------------------------------------------------|
 | `base`    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][]. Omit the `+` and the issuer for XRP. |
 | `counter` | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][]. Omit the `+` and the issuer for XRP. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `date` | String - [Timestamp][] | Return an exchange rate for the specified time. Defaults to the current time. |
-| `strict` | Boolean | If false, allow rates derived from less than 10 exchanges. Defaults to true. |
+| Field    | Value                  | Description                              |
+|:---------|:-----------------------|:-----------------------------------------|
+| `date`   | String - [Timestamp][] | Return an exchange rate for the specified time. The default is the current time. |
+| `strict` | Boolean                | If `false`, allow rates derived from less than 10 exchanges. The default is `true`. |
 
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
+| Field    | Value  | Description                                              |
+|:---------|:-------|:---------------------------------------------------------|
 | `result` | String | The value `success` indicates that this is a successful response. |
-| `rate` | Number | The requested exchange rate, or `0` if the exchange rate could not be determined. |
+| `rate`   | Number | The requested exchange rate, or `0` if the exchange rate could not be determined. |
 
 All exchange rates are calcuated by converting the base currency and counter currency to XRP.
 
@@ -948,26 +954,26 @@ GET /v2/normalize
 
 You must provide at least some of the following query parameters:
 
-| Field             | Value   | Description |
-|-------------------|---------|-------------|
-| `amount` | Number  | (Required) Amount of currency to normalize. |
-| `currency` | String - [Currency Code][] | The currency code of the `amount` to convert from. Defaults to XRP. |
-| `issuer` | String - [Address][] | The issuer of the currency to convert from. (Required if `currency` is not XRP.) |
-| `exchange_currency` | String - [Currency Code][] | The currency to convert to. Defaults to XRP. |
-| `exchange_issuer` | String - [Address][] | The issuer of the currency to convert to. (Required if `exchange_currency` is not XRP.) |
-| `date` | String - [Timestamp][] | Convert according to the exchange rate at this time. Defaults to the current time. |
-| `strict` | Boolean | If `true`, do not use exchange rates that are determined by less than 10 exchanges. Defaults to `true`. |
+| Field               | Value                      | Description               |
+|:--------------------|:---------------------------|:--------------------------|
+| `amount`            | Number                     | (Required) Amount of currency to normalize. |
+| `currency`          | String - [Currency Code][] | The currency code of the `amount` to convert from. The default is XRP. |
+| `issuer`            | String - [Address][]       | The issuer of the currency to convert from. (Required if `currency` is not XRP.) |
+| `exchange_currency` | String - [Currency Code][] | The currency to convert to. The default is XRP. |
+| `exchange_issuer`   | String - [Address][]       | The issuer of the currency to convert to. (Required if `exchange_currency` is not XRP.) |
+| `date`              | String - [Timestamp][]     | Convert according to the exchange rate at this time. The default is the current time. |
+| `strict`            | Boolean                    | If `true`, do not use exchange rates that are determined by less than 10 exchanges. The default is `true`. |
 
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `amount` | Number | Pre-conversion amount specified in the request. |
+| Field       | Value  | Description                                           |
+|:------------|:-------|:------------------------------------------------------|
+| `result`    | String | The value `success` indicates that this is a successful response. |
+| `amount`    | Number | Pre-conversion amount specified in the request.       |
 | `converted` | Number | Post-conversion amount of the `exchange_currency`, or `0` if the exchange rate could not be determined. |
-| `rate` | Number | Exchange rate used to calculate the conversion, or `0` if the exchange rate could not be determined. |
+| `rate`      | Number | Exchange rate used to calculate the conversion, or `0` if the exchange rate could not be determined. |
 
 All exchange rates are calculating by converting both currencies to XRP.
 
@@ -1006,7 +1012,7 @@ Retrieve per account per day aggregated payment summaries
 *REST*
 
 ```
-GET /v2/reports/{:date}
+GET /v2/reports/{date}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -1015,30 +1021,30 @@ GET /v2/reports/{:date}
 
 This method uses the following URL parameter:
 
-| Field | Value  | Description |
-|-------|--------|-------------|
-| `date` | String | (Optional) UTC query date. If omitted, use the current day. |
+| Field  | Value  | Description                                                   |
+|:-------|:-------|:--------------------------------------------------------------|
+| `date` | String | _(Optional)_ UTC query date. If omitted, use the current day. |
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value   | Description |
-|----------|---------|-------------|
-| `accounts` | Boolean | If true, include lists of counterparty accounts. Defaults to false. |
-| `payments` | Boolean | If true, include lists of individual payments. Defaults to false. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
+| Field      | Value   | Description                                           |
+|:-----------|:--------|:------------------------------------------------------|
+| `accounts` | Boolean | If `true`, include lists of counterparty accounts. The default is `false`. |
+| `payments` | Boolean | If `true`, include lists of individual payments. The default is `false`. |
+| `format`   | String  | Format of returned results: `csv` or `json`. The default is `json`. |
+| `limit`    | Integer | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`   | String  | [Pagination](#pagination) key from previously returned response. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `date` | String - [Timestamp][] | The date for which this report applies. |
-| `count` | Integer | Number of reports returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
+| Field     | Value                        | Description                       |
+|:----------|:-----------------------------|:----------------------------------|
+| `result`  | String                       | The value `success` indicates that this is a successful response. |
+| `date`    | String - [Timestamp][]       | The date for which this report applies. |
+| `count`   | Integer                      | Number of reports returned.       |
+| `marker`  | String                       | (May be omitted) [Pagination](#pagination) marker. |
 | `reports` | Array of [Reports Objects][] | The requested reports. Each report pertains to a single account. |
 
 **Caution:** This method may return a very large amount of data (more than 1 megabyte), which may cause poor performance in your client application.
@@ -1179,25 +1185,25 @@ GET /v2/stats
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `family` | String  | If provided, filter results to a single family of stats: `type`, `result`, or `metric`. By default, provides all stats from all families. |
-| `metrics` | String  | Filter results to one or more metrics (in a comma-separated list). Requires the `family` of the metrics to be specified. By default, provides all metrics in the family. |
-| `start` | String - [Timestamp][] | Filter results to this time and later. |
-| `end` | String - [Timestamp][] | Filter results to this time and earlier. |
-| `interval` | String  | Aggregation interval (`hour`,`day`,`week`, defaults to `day`) |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `descending` | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `family`     | String                 | If provided, filter results to a single family of stats: `type`, `result`, or `metric`. By default, provides all stats from all families. |
+| `metrics`    | String                 | Filter results to one or more metrics (in a comma-separated list). Requires the `family` of the metrics to be specified. By default, provides all metrics in the family. |
+| `start`      | String - [Timestamp][] | Filter results to this time and later. |
+| `end`        | String - [Timestamp][] | Filter results to this time and earlier. |
+| `interval`   | String                 | Aggregation interval (`hour`, `day`, or `week`). The default is `day`. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `descending` | Boolean                | If `true`, return results in reverse chronological order. The default is `false`. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 ##### Families and Metrics
 
 The `family` and `metrics` query parameters provide a way to filter results to a specific subset of all metrics available for transactions in any given interval. Each metric is tied to a specific family, as follows:
 
-| Family | Included Metrics | Meaning |
-|--------|------------------|---------|
-| `type` | All XRP Ledger [transaction types](https://developers.ripple.com/transaction-formats.html), including `Payment`, `AccountSet`, `OfferCreate`, and others. | Number of transactions of the given type that occurred during the interval. |
+| Family   | Included Metrics | Meaning |
+|:---------|:-----------------|:--------|
+| `type`   | All XRP Ledger [transaction types](https://developers.ripple.com/transaction-formats.html), including `Payment`, `AccountSet`, `OfferCreate`, and others. | Number of transactions of the given type that occurred during the interval. |
 | `result` | All [transaction result codes](https://developers.ripple.com/transaction-results.html) (string codes, not the numeric codes), including `tesSUCCESS`, `tecPATH_DRY`, and many others. | Number of transactions that resulted in the given code during the interval. |
 | `metric` | Data-API defined Special Transaction Metrics. | (Varies) |
 
@@ -1205,26 +1211,26 @@ The `family` and `metrics` query parameters provide a way to filter results to a
 
 The Data API derives the following values for every interval. These metrics are part of the `metric` family.
 
-| Field  | Value | Description |
-|--------|-------|-------------|
+| Field              | Value  | Description                                    |
+|:-------------------|:-------|:-----------------------------------------------|
 | `accounts_created` | Number | The number of new accounts funded during this interval. |
-| `exchanges_count` | Number | The number of currency exchanges that occurred during this interval. |
-| `ledger_count` | Number | The number of ledgers closed during this interval. |
-| `ledger_interval` | Number | The average number of seconds between ledgers closing during this interval. |
-| `payments_count` | Number | The number of payments from one account to another during this interval. |
-| `tx_per_ledger` | Number | The average number of transactions per ledger in this interval. |
+| `exchanges_count`  | Number | The number of currency exchanges that occurred during this interval. |
+| `ledger_count`     | Number | The number of ledgers closed during this interval. |
+| `ledger_interval`  | Number | The average number of seconds between ledgers closing during this interval. |
+| `payments_count`   | Number | The number of payments from one account to another during this interval. |
+| `tx_per_ledger`    | Number | The average number of transactions per ledger in this interval. |
 
 If any of the metrics have a value of 0, they are omitted from the results.
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of reports returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `stats` | Array of stats objects | The requested stats. Omits metrics with a value of 0, and intervals that have no nonzero metrics. |
+| Field    | Value                  | Description                              |
+|:---------|:-----------------------|:-----------------------------------------|
+| `result` | String                 | The value `success` indicates that this is a successful response. |
+| `count`  | Integer                | Number of reports returned.              |
+| `marker` | String                 | (May be omitted) [Pagination](#pagination) marker. |
+| `stats`  | Array of stats objects | The requested stats. Omits metrics with a value of 0, and intervals that have no nonzero metrics. |
 
 #### Example
 
@@ -1262,133 +1268,6 @@ Response:
 
 
 
-
-## Get Capitalization
-[[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/capitalization.js "Source")
-
-Get the total amount of a single currency issued by a single issuer, also known as the [market capitalization](https://en.wikipedia.org/wiki/Market_capitalization). _(New in [v2.0.4][])_
-
-#### Request Format
-
-<!-- MULTICODE_BLOCK_START -->
-
-*REST*
-
-```
-GET /v2/capitaliztion/{:currency}
-```
-
-<!-- MULTICODE_BLOCK_END -->
-
-[Try it! >](https://developers.ripple.com/data-api-v2-tool.html#get-capitalization)
-
-This method requires the following URL parameters:
-
-| Field     | Value                      | Description |
-|-----------|----------------------------|-------------|
-| :currency | String | Currency to look up, in the form of [currency](#currency-code)+[issuer](#addresses). XRP is disallowed. |
-
-
-Optionally, you can provide the following query parameters:
-
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `start` | String - [Timestamp][] | Start time of query range. Defaults to `2013-01-01T00:00:00Z`. |
-| `end` | String - [Timestamp][] | End time of query range. Defaults to the current time. |
-| `interval` | String  | Aggregation interval - `day`, `week`, or `month`. Defaults to `day`. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `descending` | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| `adjusted` | Boolean | If true, do not count known issuer-owned addresses towards market capitalization. Defaults to true. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
-
-If the request omits both `start` and `end`, the API returns only the most recent sample.
-
-
-#### Response Format
-A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
-
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of reports returned. |
-| `currency` | String | Currency requested. |
-| `issuer` | String | Issuer requested. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `rows` | Array of issuer capitalization objects | The requested capitalization data. |
-
-Each **issuer capitalization object** has the following fields:
-
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `date` | String - [Timestamp][] | The start time of the interval this object represents. |
-| `amount` | [String - Number][] | The total amount of currency issued by the issuer as of the start of this interval. |
-
-#### Example
-
-Request:
-
-```
-GET /v2/capitalization/USD+rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q?start=2015-01-01T00:00:00Z&end=2015-10-31&interval=month
-```
-
-Response:
-
-```
-200 OK
-{
-  "result": "success",
-  "currency": "USD",
-  "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-  "count": 10,
-  "rows": [
-    {
-      "date": "2015-01-01T00:00:00Z",
-      "amount": "4212940.254176095"
-    },
-    {
-      "date": "2015-02-01T00:00:00Z",
-      "amount": "5102817.663782776"
-    },
-    {
-      "date": "2015-03-01T00:00:00Z",
-      "amount": "4179270.8503426993"
-    },
-    {
-      "date": "2015-04-01T00:00:00Z",
-      "amount": "2609239.954946732"
-    },
-    {
-      "date": "2015-05-01T00:00:00Z",
-      "amount": "2262976.3681027396"
-    },
-    {
-      "date": "2015-06-01T00:00:00Z",
-      "amount": "2401904.277326213"
-    },
-    {
-      "date": "2015-07-01T00:00:00Z",
-      "amount": "2007614.760195671"
-    },
-    {
-      "date": "2015-08-01T00:00:00Z",
-      "amount": "2286058.6013003727"
-    },
-    {
-      "date": "2015-09-01T00:00:00Z",
-      "amount": "2070512.4729615194"
-    },
-    {
-      "date": "2015-10-01T00:00:00Z",
-      "amount": "2140238.7719266433"
-    }
-  ]
-}
-```
-
-
-
-
 ## Get Active Accounts
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/activeAccounts.js "Source")
 
@@ -1401,7 +1280,7 @@ Get information on which accounts are actively trading in a specific currency pa
 *REST*
 
 ```
-GET /v2/active_accounts/{:base}/{:counter}
+GET /v2/active_accounts/{base}/{counter}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -1410,46 +1289,46 @@ GET /v2/active_accounts/{:base}/{:counter}
 
 This method requires the following URL parameters:
 
-| Field    | Value  | Description |
-|----------|--------|-------------|
-| :base    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
-| :counter | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+| Field     | Value  | Description                                             |
+|:----------|:-------|:--------------------------------------------------------|
+| `base`    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
+| `counter` | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
 
 Optionally, you can provide the following query parameters:
 
-| Field              | Value   | Description |
-|--------------------|---------|-------------|
-| `period` | String  | Get results for trading activity during a chosen time period. Valid periods are `1day`, `3day`, or `7day`. Defaults to `1day`. |
-| `date` | String  | Get results for the period starting at this time. Defaults to the most recent period available. |
+| Field               | Value   | Description                                  |
+|:--------------------|:--------|:---------------------------------------------|
+| `period`            | String  | Get results for trading activity during a chosen time period. Valid periods are `1day`, `3day`, or `7day`. The default is `1day`. |
+| `date`              | String  | Get results for the period starting at this time. The default is the most recent period available. |
 | `include_exchanges` | Boolean | Include individual exchanges for each account in the results. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| `format`            | String  | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of accounts returned. |
-| `exchanges_count` | Integer | Total number of exchanges in the period. |
-| `accounts` | Array of active Account Trading Objects | Active trading accounts for the period. |
+| Field             | Value                                   | Description    |
+|:------------------|:----------------------------------------|:---------------|
+| `result`          | String                                  | The value `success` indicates that this is a successful response. |
+| `count`           | Integer                                 | Number of accounts returned. |
+| `exchanges_count` | Integer                                 | Total number of exchanges in the period. |
+| `accounts`        | Array of active Account Trading Objects | Active trading accounts for the period. |
 
-Each "Account Trading Object" describes the activity of a single account during this time period, and has the following fields:
+Each **Account Trading Object** describes the activity of a single account during this time period, and has the following fields:
 
-| Field           | Value            | Description |
-|-----------------|------------------|-------------|
-| `buy` | Object | Summary of currency exchanges buying the base currency|
-| `buy.base_volume` | Number | Amount of base currency the account bought in this period. |
-| `buy.counter_volume` | Number | Amount of counter currency the account sold in this period. |
-| `buy.count` | Number | Number of trades that bought the base currency in this period. |
-| `sell` | Object | Summary of currency changes selling the base currency. |
-| `sell.base_volume` | Number | Amount of the base currency the account sold this period. |
-| `sell.counter_volume` | Number | Amount of the counter currency the account bought this period. |
-| `sell.count` | Number | Number of trades that sold the base currency. |
-| `account` | String - Address | The address whose activity this object describes. |
-| `base_volume` | Number | The total volume of the base currency the account bought and sold in this period. |
-| `counter_volume` | Number | The total volume of the counter currency the account bought and sold in this period. |
-| `count` | Number | The total number of exchanges the account made during this period. |
+| Field                 | Value                | Description                   |
+|:----------------------|:---------------------|:------------------------------|
+| `buy`                 | Object               | Summary of currency exchanges buying the base currency |
+| `buy.base_volume`     | Number               | Amount of base currency the account bought in this period. |
+| `buy.counter_volume`  | Number               | Amount of counter currency the account sold in this period. |
+| `buy.count`           | Number               | Number of trades that bought the base currency in this period. |
+| `sell`                | Object               | Summary of currency changes selling the base currency. |
+| `sell.base_volume`    | Number               | Amount of the base currency the account sold this period. |
+| `sell.counter_volume` | Number               | Amount of the counter currency the account bought this period. |
+| `sell.count`          | Number               | Number of trades that sold the base currency. |
+| `account`             | String - [Address][] | The address whose activity this object describes. |
+| `base_volume`         | Number               | The total volume of the base currency the account bought and sold in this period. |
+| `counter_volume`      | Number               | The total volume of the counter currency the account bought and sold in this period. |
+| `count`               | Number               | The total number of exchanges the account made during this period. |
 
 #### Example
 
@@ -1564,31 +1443,33 @@ GET /v2/network/exchange_volume
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value   | Description |
-|----------|---------|-------------|
-| `live` | String | Return a live rolling window of this length of time. Valid values are `day`, `hour`, or `minute`. _(New in [v2.3.0][])_ |
-| `exchange_currency` | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
-| `exchange_issuer` | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field               | Value                      | Description               |
+|:--------------------|:---------------------------|:--------------------------|
+| `live`              | String                     | Return a live rolling window of this length of time. Valid values are `day`, `hour`, or `minute`. _(New in [v2.3.0][])_ |
+| `exchange_currency` | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. The default is XRP. |
+| `exchange_issuer`   | String - [Address][]       | Normalize results to the specified `currency` issued by this issuer. |
+| `format`            | String                     | Format of returned results: `csv` or `json`. The default is `json`. |
+
+The `start`, `end`, `interval`, `limit`, and `marker` parameters have been removed in [v2.3.5][].
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of results returned. |
-| `rows` | Array of exchange [Volume Objects][] | Exchange volumes for each interval in the requested time period. (By default, this array contains only the most recent complete interval. If `live` is specified and `interval` isn't, this array contains the specified rolling window instead.) |
+| Field    | Value                                | Description                |
+|:---------|:-------------------------------------|:---------------------------|
+| `result` | String                               | The value `success` indicates that this is a successful response. |
+| `count`  | Integer                              | Number of results returned. |
+| `rows`   | Array of exchange [Volume Objects][] | Exchange volumes for each interval in the requested time period. (By default, this array contains only the most recent complete interval. If `live` is specified and `interval` isn't, this array contains the specified rolling window instead.) |
 
 Each object in the `components` array of the Volume Objects represent the volume of exchanges in a market between two currencies, and has the following fields:
 
-| Field  | Value  | Description |
-|--------|--------|-------------|
-| `count` | Number | The number of exchanges in this market during this interval. |
-| `rate` | Number | The exchange rate from the base currency to the display currency. |
-| `amount` | Number | The amount of volume in the market, in units of the base currency. |
-| `base` | Object | The `currency` and `issuer` of the base currency of this market. There is no `issuer` for XRP. |
-| `counter` | Object | The `currency` and `issuer` of the counter currency of this market. There is no `issuer` for XRP. |
+| Field              | Value  | Description                                    |
+|:-------------------|:-------|:-----------------------------------------------|
+| `count`            | Number | The number of exchanges in this market during this interval. |
+| `rate`             | Number | The exchange rate from the base currency to the display currency. |
+| `amount`           | Number | The amount of volume in the market, in units of the base currency. |
+| `base`             | Object | The `currency` and `issuer` of the base currency of this market. There is no `issuer` for XRP. |
+| `counter`          | Object | The `currency` and `issuer` of the counter currency of this market. There is no `issuer` for XRP. |
 | `converted_amount` | Number | The total amount of volume in the market, converted to the display currency. _(Before [v2.1.0][], this was `convertedAmount`.)_ |
 
 #### Example
@@ -1709,32 +1590,34 @@ GET /v2/network/payment_volume
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value   | Description |
-|----------|---------|-------------|
-| `live` | String | Return a live rolling window of this length of time. Valid values are `day`, `hour`, or `minute`. _(New in [v2.3.0][])_ |
-| `exchange_currency` | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
-| `exchange_issuer` | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field               | Value                      | Description               |
+|:--------------------|:---------------------------|:--------------------------|
+| `live`              | String                     | Return a live rolling window of this length of time. Valid values are `day`, `hour`, or `minute`. _(New in [v2.3.0][])_ |
+| `exchange_currency` | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. The default is XRP. |
+| `exchange_issuer`   | String - [Address][]       | Normalize results to the specified `currency` issued by this issuer. |
+| `format`            | String                     | Format of returned results: `csv` or `json`. The default is `json`. |
+
+The `start`, `end`, `interval`, `limit`, and `marker` parameters have been removed in [v2.3.5][].
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of results returned. |
-| `rows` | Array of payment [Volume Objects][] | Payment volumes for each interval in the requested time period. (By default, this array contains only the most recent interval. If `live` is specified and `interval` isn't, this array contains the specified rolling window instead.) |
+| Field    | Value                               | Description                 |
+|:---------|:------------------------------------|:----------------------------|
+| `result` | String                              | The value `success` indicates that this is a successful response. |
+| `count`  | Integer                             | Number of results returned. |
+| `rows`   | Array of payment [Volume Objects][] | Payment volumes for each interval in the requested time period. (By default, this array contains only the most recent interval. If `live` is specified and `interval` isn't, this array contains the specified rolling window instead.) |
 
 Each object in the `components` array of the Volume Objects represent the volume of payments for one currencies and issuer, and has the following fields:
 
-| Field  | Value  | Description |
-|--------|--------|-------------|
-| `currency` | String - [Currency Code][] | The currency of this payment volume object. |
-| `issuer` | String - [Address][] | (Omitted for XRP) The issuer of this payment volume object. |
-| `amount` | Number | Total payment volume for this currency during the interval, in units of the currency itself. |
-| `count` | Number | The total number of payments in this currency. |
-| `rate` | Number | The exchange rate between this currency and the display currency. |
-| `converted_amount` | Number | Total payment volume for this currency, converted to the display currency. _(Before [v2.1.0][], this was `convertedAmount`.)_ |
+| Field              | Value                      | Description                |
+|:-------------------|:---------------------------|:---------------------------|
+| `currency`         | String - [Currency Code][] | The currency of this payment volume object. |
+| `issuer`           | String - [Address][]       | (Omitted for XRP) The issuer of this payment volume object. |
+| `amount`           | Number                     | Total payment volume for this currency during the interval, in units of the currency itself. |
+| `count`            | Number                     | The total number of payments in this currency. |
+| `rate`             | Number                     | The exchange rate between this currency and the display currency. |
+| `converted_amount` | Number                     | Total payment volume for this currency, converted to the display currency. _(Before [v2.1.0][], this was `convertedAmount`.)_ |
 
 #### Example
 
@@ -1810,6 +1693,8 @@ Response:
 }
 ```
 
+
+
 ## Get External Markets
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/externalMarkets.js "Source")
 
@@ -1833,34 +1718,34 @@ GET /v2/network/external_markets
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value   | Description |
-|----------|---------|-------------|
-| `period` | String  | Aggregation Period - valid intervals are `1hour`, `1day`, `3day`, `7day`, or `30day`. Defaults to `1day`. |
-| `exchange_currency` | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. Defaults to XRP. |
-| `exchange_issuer` | String - [Address][] | Normalize results to the specified `currency` issued by this issuer. |
+| Field               | Value                      | Description               |
+|:--------------------|:---------------------------|:--------------------------|
+| `period`            | String                     | Aggregation Period - valid intervals are `1hour`, `1day`, `3day`, `7day`, or `30day`. The default is `1day`. |
+| `exchange_currency` | String - [Currency Code][] | Normalize all amounts to use this as a display currency. If not XRP, `exchange_issuer` is also required. The default is XRP. |
+| `exchange_issuer`   | String - [Address][]       | Normalize results to the specified `currency` issued by this issuer. |
 
 
 #### Response Format ####
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `data` | Object | Contains data for the specified period |
-| `data.date` | String | Date at which this period was calculated. |
-| `data.total` | Number | Total XRP volume exchanged during the period. |
-| `data.period` | String | Name of the period queried. |
+| Field         | Value  | Description                                         |
+|:--------------|:-------|:----------------------------------------------------|
+| `result`      | String | The value `success` indicates that this is a successful response. |
+| `data`        | Object | Contains data for the specified period.             |
+| `data.date`   | String | Date at which this period was calculated.           |
+| `data.total`  | Number | Total XRP volume exchanged during the period.       |
+| `data.period` | String | Name of the period queried.                         |
 
 Each object in the `components` array of the Volume Objects represent the volume of a single external market.  Not all fields will be present for each market, depending on availability.
 
-| Field  | Value  | Description |
-|--------|--------|-------------|
-| `source` | String | Domain name of the specific external market. |
-| `base_volume` | Number | Exchange volume in terms of the base currency (XRP) |
-| `counter_volume` | Number | Exchange volume in terms of the counter currency. |
-| `base_currecy` | String | Base currency of the market pair.  |
-| `counter_currency` | String | Counter currency of the market pair. |
-| `rate` | Number | Exchange rate. |
+| Field              | Value  | Description                                    |
+|:-------------------|:-------|:-----------------------------------------------|
+| `source`           | String | Domain name of the specific external market.   |
+| `base_volume`      | Number | Exchange volume in terms of the base currency (XRP). |
+| `counter_volume`   | Number | Exchange volume in terms of the counter currency. |
+| `base_currecy`     | String | Base currency of the market pair.              |
+| `counter_currency` | String | Counter currency of the market pair.           |
+| `rate`             | Number | Exchange rate.                                 |
 
 #### Example ####
 
@@ -1954,33 +1839,33 @@ GET /v2/network/xrp_distribution
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `start`      | String - [Timestamp][]  | Start time of query range. Defaults to the start of the most recent interval. |
-| `end`        | String - [Timestamp][]  | End time of query range. Defaults to the end of the most recent interval. |
-| `limit`    | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker`   | String  | [Pagination](#pagination) key from previously returned response. |
-| `descending` | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| `format`     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Start time of query range. The default is the start of the most recent interval. |
+| `end`        | String - [Timestamp][] | End time of query range. The default is the end of the most recent interval. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `descending` | Boolean                | If `true`, return results in reverse chronological order. The default is `false`. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `count` | Integer | Number of rows returned. |
-| `rows` | Array of Distribution Objects | Weekly snapshots of the XRP distribution. |
+| Field    | Value                         | Description                       |
+|:---------|:------------------------------|:----------------------------------|
+| `result` | String                        | The value `success` indicates that the body represents a successful response. |
+| `count`  | Integer                       | Number of rows returned.          |
+| `rows`   | Array of Distribution Objects | Weekly snapshots of the XRP distribution. |
 
 Each Distribution Object has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `date` | String - [Timestamp][] | The time of this snapshot. |
-| `total` | String | Total XRP in existence. |
-| `undistributed` | String | Aggregate amount of XRP held by Ripple (the company). |
-| `distributed` | String | Aggregate amount of XRP held by others. |
+| Field           | Value                  | Description                       |
+|:----------------|:-----------------------|:----------------------------------|
+| `date`          | String - [Timestamp][] | The time of this snapshot.        |
+| `total`         | String                 | Total XRP in existence.           |
+| `undistributed` | String                 | Aggregate amount of XRP held by Ripple (the company). |
+| `distributed`   | String                 | Aggregate amount of XRP held by others. |
 
 #### Example
 
@@ -2030,7 +1915,7 @@ GET /v2/network/top_currencies
 *By Date*
 
 ```
-GET /v2/network/top_currencies/{:date}
+GET /v2/network/top_currencies/{date}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -2039,39 +1924,39 @@ GET /v2/network/top_currencies/{:date}
 
 This method uses the following URL parameter:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `date` | String - ISO 8601 Date | (Optional) Historical date to query. If omitted, use the most recent date available. |
+| Field  | Value                  | Description                                |
+|:-------|:-----------------------|:-------------------------------------------|
+| `date` | String - ISO 8601 Date | _(Optional)_ Historical date to query. If omitted, use the most recent date available. |
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value | Description |
-|----------|-------|-------------|
-| `limit`  | Integer | Maximum results per page. Defaults to 1000. Cannot be more than 1000. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value   | Description                                             |
+|:---------|:--------|:--------------------------------------------------------|
+| `limit`  | Integer | Maximum results per page. The default is 1000. Cannot be more than 1000. |
+| `format` | String  | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `date` | String - [Timestamp][] | When this data was measured. |
-| `count` | Integer | Number of objects in the `currencies` field. |
+| Field        | Value                         | Description                   |
+|:-------------|:------------------------------|:------------------------------|
+| `result`     | String                        | The value `success` indicates that this is a successful response. |
+| `date`       | String - [Timestamp][]        | When this data was measured.  |
+| `count`      | Integer                       | Number of objects in the `currencies` field. |
 | `currencies` | Array of Top Currency Objects | The top currencies for this data sample. Each member represents one currency, by currency code and issuer. |
 
 Each Top Currency Object has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `currency` | String - [Currency Code][] | The currency this object describes. |
-| `issuer` | String - [Address][] | The XRP Ledger address that issues this currency. |
-| `avg_exchange_count` | [String - Number][] | Daily average number of [exchanges](#exchange-objects) |
-| `avg_exchange_volume` | [String - Number][] | Daily average volume of exchanges, normalized to XRP |
-| `avg_payment_count` | [String - Number][] | Daily average number of [payments](#payment-objects) |
-| `avg_payment_volume` | [String - Number][] | Daily average volume of payments, normalized to XRP |
-| `issued_value` | [String - Number][] | Total amount of this currency issued by this issuer, normalized to XRP |
+| Field                 | Value                      | Description             |
+|:----------------------|:---------------------------|:------------------------|
+| `currency`            | String - [Currency Code][] | The currency this object describes. |
+| `issuer`              | String - [Address][]       | The XRP Ledger address that issues this currency. |
+| `avg_exchange_count`  | [String - Number][]        | Daily average number of [exchanges](#exchange-objects). |
+| `avg_exchange_volume` | [String - Number][]        | Daily average volume of exchanges, normalized to XRP. |
+| `avg_payment_count`   | [String - Number][]        | Daily average number of [payments](#payment-objects). |
+| `avg_payment_volume`  | [String - Number][]        | Daily average volume of payments, normalized to XRP. |
+| `issued_value`        | [String - Number][]        | Total amount of this currency issued by this issuer, normalized to XRP. |
 
 #### Example
 
@@ -2132,7 +2017,7 @@ GET /v2/network/top_markets
 *By Date*
 
 ```
-GET /v2/network/top_markets/{:date}
+GET /v2/network/top_markets/{date}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -2141,40 +2026,40 @@ GET /v2/network/top_markets/{:date}
 
 This method uses the following URL parameter:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `date` | String - ISO 8601 Date | (Optional) Historical date to query. If omitted, use the most recent date available. |
+| Field  | Value                  | Description                                |
+|:-------|:-----------------------|:-------------------------------------------|
+| `date` | String - ISO 8601 Date | _(Optional)_ Historical date to query. If omitted, use the most recent date available. |
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value | Description |
-|----------|-------|-------------|
-| `limit`  | Integer | Maximum results per page. Defaults to 1000. Cannot be more than 1000. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value   | Description                                             |
+|:---------|:--------|:--------------------------------------------------------|
+| `limit`  | Integer | Maximum results per page. The default is 1000. Cannot be more than 1000. |
+| `format` | String  | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `date` | String - [Timestamp][] | The end of the rolling window over which this data was calculated. |
-| `count` | Integer | Number of results in the `markets` field. |
+| Field     | Value                       | Description                        |
+|:----------|:----------------------------|:-----------------------------------|
+| `result`  | String                      | The value `success` indicates that this is a successful response. |
+| `date`    | String - [Timestamp][]      | The end of the rolling window over which this data was calculated. |
+| `count`   | Integer                     | Number of results in the `markets` field. |
 | `markets` | Array of Top Market Objects | The top markets for this data sample. Each member represents a currency pair. |
 
 Each Top Market object has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `base_currency` | String - [Currency Code][] | The base currency for this market. |
-| `base_issuer` | String - [Address][] | (Omitted if `base_currency` is XRP) The XRP Ledger address that issues the base currency. |
-| `counter_currency` | String - [Currency Code][] | The counter currency for this market. |
-| `counter_issuer` | String - [Address][] | (Omitted if `counter_currency` is XRP) The XRP Ledger address that issues the counter currency. |
-| `avg_base_volume` | String | Daily average volume in terms of the base currency. |
-| `avg_counter_volume` | String | Daily average volume in terms of the counter currency. |
-| `avg_exchange_count` | String | Daily average number of [exchanges](#exchange-objects) |
-| `avg_volume` | String | Daily average volume, normalized to XRP |
+| Field                | Value                      | Description              |
+|:---------------------|:---------------------------|:-------------------------|
+| `base_currency`      | String - [Currency Code][] | The base currency for this market. |
+| `base_issuer`        | String - [Address][]       | (Omitted if `base_currency` is XRP) The XRP Ledger address that issues the base currency. |
+| `counter_currency`   | String - [Currency Code][] | The counter currency for this market. |
+| `counter_issuer`     | String - [Address][]       | (Omitted if `counter_currency` is XRP) The XRP Ledger address that issues the counter currency. |
+| `avg_base_volume`    | String                     | Daily average volume in terms of the base currency. |
+| `avg_counter_volume` | String                     | Daily average volume in terms of the counter currency. |
+| `avg_exchange_count` | String                     | Daily average number of [exchanges](#exchange-objects). |
+| `avg_volume`         | String                     | Daily average volume, normalized to XRP. |
 
 #### Example
 
@@ -2239,37 +2124,37 @@ GET /v2/network/fees
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `start`    | String - [Timestamp][]  | Start time of query range. Defaults to the earliest data available. |
-| `end`      | String - [Timestamp][]  | End time of query range. Defaults to the latest data available. |
-| `interval` | String  | Aggregation interval - valid intervals are `ledger`, `hour`, or `day`. Defaults to `ledger`. |
-| `descending` | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
-| `limit`    | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker`   | String  | [Pagination](#pagination) key from previously returned response. |
-| `format`   | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Start time of query range. The default is to start from the earliest data available. |
+| `end`        | String - [Timestamp][] | End time of query range. The default is to start from the latest data available. |
+| `interval`   | String                 | Aggregation interval - valid intervals are `ledger`, `hour`, or `day`. The default is `ledger`. |
+| `descending` | Boolean                | If `true`, sort results with most recent first. By default, sort results with oldest first. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `count`  | Integer | Number of results in the `markets` field. |
-| `rows` | Array of Fee Summary Objects | Transaction cost statistics for each interval. |
+| Field    | Value                        | Description                        |
+|:---------|:-----------------------------|:-----------------------------------|
+| `result` | String                       | The value `success` indicates that this is a successful response. |
+| `marker` | String                       | (May be omitted) [Pagination](#pagination) marker. |
+| `count`  | Integer                      | Number of results in the `markets` field. |
+| `rows`   | Array of Fee Summary Objects | Transaction cost statistics for each interval. |
 
 Each Fee Summary object has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `avg` | Number | Average transaction cost paid in this interval. |
-| `min` | Number | Minimum  transaction cost paid in this interval. |
-| `max` | Number | Maximum  transaction cost paid in this interval. |
-| `total` | Number | Total XRP destroyed by transaction costs. |
-| `tx_count` | Number | Number of transactions in this interval. |
-| `date` | String - [Timestamp][] | The start time of this interval (time intervals), or the close time of this ledger (`ledger` interval). |
+| Field          | Value                      | Description                    |
+|:---------------|:---------------------------|:-------------------------------|
+| `avg`          | Number                     | Average transaction cost paid in this interval. |
+| `min`          | Number                     | Minimum  transaction cost paid in this interval. |
+| `max`          | Number                     | Maximum  transaction cost paid in this interval. |
+| `total`        | Number                     | Total XRP destroyed by transaction costs. |
+| `tx_count`     | Number                     | Number of transactions in this interval. |
+| `date`         | String - [Timestamp][]     | The start time of this interval (time intervals), or the close time of this ledger (`ledger` interval). |
 | `ledger_index` | Integer - [Ledger Index][] | (Only present in `ledger` interval) The ledger this object describes. |
 
 #### Example
@@ -2323,7 +2208,7 @@ Response:
 ## Get Fee Stats
 [[Source]<br>](https://github.com/ripple/rippled-historical-database/blob/develop/api/routes/network/getFeeStats.js "Source")
 
-Returns snapshots of the metrics derived from rippled's fee command. _(New in [v2.4.0][])_
+Returns snapshots of the metrics derived from `rippled`'s [`fee` command](https://developers.ripple.com/fee.html). _(New in [v2.3.2][])_
 
 #### Request Format
 
@@ -2341,39 +2226,39 @@ GET /v2/network/fee_stats
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `start`    | String - [Timestamp][]  | Start time of query range. Defaults to the earliest data available. |
-| `end`      | String - [Timestamp][]  | End time of query range. Defaults to the latest data available. |
-| `interval` | String  | Snapshot Interval - valid intervals are `minute`, `hour`, or `day`. Default interval is 5 seconds. |
-| `descending` | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
-| `limit`    | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker`   | String  | [Pagination](#pagination) key from previously returned response. |
-| `format`   | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Start time of query range. The default is to start from the earliest data available. |
+| `end`        | String - [Timestamp][] | End time of query range.The default is to end at the latest data available. |
+| `interval`   | String                 | The interval of the snapshots. Valid intervals are `minute`, `hour`, or `day`. Default interval is 5 seconds. |
+| `descending` | Boolean                | If `true`, sort results with most recent first. By default, sort results with oldest first. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `count`  | Integer | Number of results in the `markets` field. |
-| `rows` | Array of Fee Summary Objects | Transaction cost statistics for each interval. |
+| Field    | Value                        | Description                        |
+|:---------|:-----------------------------|:-----------------------------------|
+| `result` | String                       | The value `success` indicates that this is a successful response. |
+| `marker` | String                       | (May be omitted) [Pagination](#pagination) marker. |
+| `count`  | Integer                      | Number of results in the `markets` field. |
+| `rows`   | Array of Fee Summary Objects | Transaction cost statistics for each interval. |
 
-Each Fee Summary object has the following fields:
+Each **Fee Summary Object** has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `date` | String - [Timestamp][] | The date-time this snapshot was taken. |
-| `current_ledger_size` | Number | Number of transactions in the current ledger at the specified time. |
-| `expected_ledger_size` | Number | Number of transactions expected in the next ledger at the specified time. |
-| `current_queue_size` | Number | Number of transactions queued for inclusion in future ledgers. |
-| `pct_max_queue_size` | Number | current queue size in terms of percentage of maximum queue size. |
-| `median_fee` | Number | Median fee of transactions in the current ledger. |
-| `minimum_fee` | Number | Minimum fee for inclusion in any ledger. |
-| `open_ledger_fee` | Cost threshold for inclusion in the ledger open at the time of the snapshot |
+| Field                  | Value                  | Description                |
+|:-----------------------|:-----------------------|:---------------------------|
+| `date`                 | String - [Timestamp][] | The date-time this snapshot was taken. |
+| `current_ledger_size`  | Number                 | Number of transactions in the current ledger at the specified time. |
+| `expected_ledger_size` | Number                 | Number of transactions expected in the next ledger at the specified time. |
+| `current_queue_size`   | Number                 | Number of transactions queued for inclusion in future ledgers. |
+| `pct_max_queue_size`   | Number                 | current queue size in terms of percentage of maximum queue size. |
+| `median_fee`           | Number                 | Median fee of transactions in the current ledger. |
+| `minimum_fee`          | Number                 | Minimum fee for inclusion in any ledger. |
+| `open_ledger_fee`      | Number                 | Cost threshold for inclusion in the ledger open at the time of the snapshot. |
 
 #### Example
 
@@ -2442,23 +2327,23 @@ GET /v2/network/topology
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `date` | String - [Timestamp][]  | Date and time for historical query. By default, uses the most recent data available. |
-| `verbose` | Boolean | If `true`, include additional details about each server where available. Defaults to `false`. |
+| Field     | Value                  | Description                             |
+|:----------|:-----------------------|:----------------------------------------|
+| `date`    | String - [Timestamp][] | Date and time for historical query. By default, uses the most recent data available. |
+| `verbose` | Boolean                | If `true`, include additional details about each server where available. The default is `false`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `date`   | String - [Timestamp][] | The time of this measurement. |
-| `node_count`  | Integer | Number of `rippled` servers in the topology. |
-| `link_count`  | Integer | Number of links in the topology. |
-| `nodes` | Array of [Server Objects][] | Details of `rippled` servers in the peer-to-peer network. |
-| `links` | Array of [Link Objects][] | Network connections between `rippled` servers in the peer-to-peer network. |
+| Field        | Value                       | Description                     |
+|:-------------|:----------------------------|:--------------------------------|
+| `result`     | String                      | The value `success` indicates that the body represents a successful response. |
+| `date`       | String - [Timestamp][]      | The time of this measurement.   |
+| `node_count` | Integer                     | Number of `rippled` servers in the topology. |
+| `link_count` | Integer                     | Number of links in the topology. |
+| `nodes`      | Array of [Server Objects][] | Details of `rippled` servers in the peer-to-peer network. |
+| `links`      | Array of [Link Objects][]   | Network connections between `rippled` servers in the peer-to-peer network. |
 
 #### Example
 
@@ -2546,22 +2431,22 @@ GET /v2/network/topology/nodes
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `date` | String - [Timestamp][]  | Date and time for historical query. Defaults to most recent data. |
-| `verbose` | Boolean | If `true`, return full details for each server. Defaults to `false`. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field     | Value                  | Description                             |
+|:----------|:-----------------------|:----------------------------------------|
+| `date`    | String - [Timestamp][] | Date and time for historical query. The default is most recent data. |
+| `verbose` | Boolean                | If `true`, return full details for each server. The default is `false`. |
+| `format`  | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `date`  | String - [Timestamp][] | When this the data was measured. |
-| `count` | Integer | Number of `rippled` servers described. |
-| `nodes` | Array of [Server Objects][] | Details of the `rippled` servers in the topology. |
+| Field    | Value                       | Description                         |
+|:---------|:----------------------------|:------------------------------------|
+| `result` | String                      | The value `success` indicates that the body represents a successful response. |
+| `date`   | String - [Timestamp][]      | When this the data was measured.    |
+| `count`  | Integer                     | Number of `rippled` servers described. |
+| `nodes`  | Array of [Server Objects][] | Details of the `rippled` servers in the topology. |
 
 #### Example
 
@@ -2628,7 +2513,7 @@ Get information about a single `rippled` server by its [node public key](#public
 *REST*
 
 ```
-GET /v2/network/topology/nodes/{:pubkey}
+GET /v2/network/topology/nodes/{pubkey}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -2637,8 +2522,8 @@ GET /v2/network/topology/nodes/{:pubkey}
 
 This method requires the following URL parameters:
 
-| Field    | Value   | Description |
-|----------|---------|-------------|
+| Field    | Value                           | Description                     |
+|:---------|:--------------------------------|:--------------------------------|
 | `pubkey` | String - Base-58 [Public Key][] | Node public key of the server to look up. |
 
 This method takes no query parameters.
@@ -2647,8 +2532,8 @@ This method takes no query parameters.
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with a **[Server Object][]** in the response with the following additional field:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
+| Field    | Value  | Description                                              |
+|:---------|:-------|:---------------------------------------------------------|
 | `result` | String | The value `success` indicates that this is a successful response. |
 
 #### Example
@@ -2709,21 +2594,21 @@ GET /v2/network/topology/links
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value   | Description |
-|----------|---------|-------------|
-| `date`   | String - [Timestamp][]  | Date and time for historical query. Defaults to most recent data available. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value                  | Description                              |
+|:---------|:-----------------------|:-----------------------------------------|
+| `date`   | String - [Timestamp][] | Date and time for historical query. The default is the most recent data available. |
+| `format` | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field    | Value | Description |
-|----------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `date`   | String - [Timestamp][] | When this data was measured. |
-| `count`  | Integer | Number of links returned. |
-| `links`  | Array of [Link Objects][] | Links between `rippled` servers. |
+| Field    | Value                     | Description                           |
+|:---------|:--------------------------|:--------------------------------------|
+| `result` | String                    | The value `success` indicates that the body represents a successful response. |
+| `date`   | String - [Timestamp][]    | When this data was measured.          |
+| `count`  | Integer                   | Number of links returned.             |
+| `links`  | Array of [Link Objects][] | Links between `rippled` servers.      |
 
 #### Example
 
@@ -2766,34 +2651,34 @@ Get details of a single validator in the [consensus network](https://developers.
 *REST*
 
 ```
-GET /v2/network/validators/{:pubkey}
+GET /v2/network/validators/{pubkey}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
 This method requires the following URL parameters:
 
-| Field     | Value   | Description |
-|-----------|---------|-------------|
-| `pubkey`  | String - Base-58 [Public Key][] | Validator public key. |
+| Field    | Value                           | Description           |
+|:---------|:--------------------------------|:----------------------|
+| `pubkey` | String - Base-58 [Public Key][] | Validator public key. |
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value  | Description                                              |
+|:---------|:-------|:---------------------------------------------------------|
+| `format` | String | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `last_datetime`  | Integer | The last reported validation vote signed by this validator. |
+| Field                   | Value                           | Description      |
+|:------------------------|:--------------------------------|:-----------------|
+| `result`                | String                          | The value `success` indicates that the body represents a successful response. |
+| `last_datetime`         | Integer                         | The last reported validation vote signed by this validator. |
 | `validation_public_key` | String - Base-58 [Public Key][] | This validator's validator public key. |
-| `domain` | String | (May be omitted) The DNS domain associated with this validator. |
-| `domain_state` | String | The value `verified` indicates that this validator has a [verified domain](https://developers.ripple.com/run-rippled-as-a-validator.html#domain-verification) controlled by the same operator as the validator. The value `AccountDomainNotFound` indicates that the "Account Domain" part of Domain Verification is not set up properly. The value `RippleTxtNotFound` indicates that the ripple.txt step of Domain Verification is not set up properly. |
+| `domain`                | String                          | (May be omitted) The DNS domain associated with this validator. |
+| `domain_state`          | String                          | The value `verified` indicates that this validator has a [verified domain](https://developers.ripple.com/run-rippled-as-a-validator.html#domain-verification) controlled by the same operator as the validator. The value `AccountDomainNotFound` indicates that the "Account Domain" part of Domain Verification is not set up properly. The value `RippleTxtNotFound` indicates that the ripple.txt step of Domain Verification is not set up properly. |
 
 #### Example
 
@@ -2840,18 +2725,18 @@ GET /v2/network/validators
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value  | Description                                              |
+|:---------|:-------|:---------------------------------------------------------|
+| `format` | String | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `last_datetime`  | Integer | Number of links returned. |
+| Field                   | Value                           | Description      |
+|:------------------------|:--------------------------------|:-----------------|
+| `result`                | String                          | The value `success` indicates that the body represents a successful response. |
+| `last_datetime`         | Integer                         | Number of links returned. |
 | `validation_public_key` | String - Base-58 [Public Key][] | Validator public key of this validator. |
 
 
@@ -2890,7 +2775,7 @@ Retrieve validation votes signed by a specified validator, including votes for l
 *REST*
 
 ```
-GET /v2/network/validators/{:pubkey}/validations
+GET /v2/network/validators/{pubkey}/validations
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -2899,29 +2784,29 @@ GET /v2/network/validators/{:pubkey}/validations
 
 This method requires the following URL parameters:
 
-| Field     | Value   | Description |
-|-----------|---------|-------------|
-| `pubkey`  | String - Base-58 [Public Key][] | Validator public key. |
+| Field    | Value                           | Description           |
+|:---------|:--------------------------------|:----------------------|
+| `pubkey` | String - Base-58 [Public Key][] | Validator public key. |
 
 Optionally, you can provide the following query parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `start` | String - [Timestamp][] | Filter results to this time and later. |
-| `end` | String - [Timestamp][] | Filter results to this time and earlier. |
-| `limit`      | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker`     | String  | [Pagination](#pagination) key from previously returned response. |
-| `format`     | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value                  | Description                              |
+|:---------|:-----------------------|:-----------------------------------------|
+| `start`  | String - [Timestamp][] | Filter results to this time and later.   |
+| `end`    | String - [Timestamp][] | Filter results to this time and earlier. |
+| `limit`  | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker` | String                 | [Pagination](#pagination) key from previously returned response. |
+| `format` | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `count` | Integer | Number of validations returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
+| Field         | Value                           | Description                |
+|:--------------|:--------------------------------|:---------------------------|
+| `result`      | String                          | The value `success` indicates that the body represents a successful response. |
+| `count`       | Integer                         | Number of validations returned. |
+| `marker`      | String                          | (May be omitted) [Pagination](#pagination) marker. |
 | `validations` | Array of [Validation Objects][] | The requested validations. |
 
 
@@ -2998,24 +2883,24 @@ GET /v2/network/validations
 
 Optionally, you can provide the following query parameters:
 
-| Field    | Value | Description |
-|----------|-------|-------------|
-| `start`  | String - [Timestamp][] | Filter results to this time and later. |
-| `end`    | String - [Timestamp][] | Filter results to this time and earlier. |
-| `limit`  | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
-| `descending` | Boolean | If `true`, return results sorted with earliest first. Otherwise, return oldest results first. Defaults to `false`.
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Filter results to this time and later. |
+| `end`        | String - [Timestamp][] | Filter results to this time and earlier. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
+| `descending` | Boolean                | If `true`, return results sorted with earliest first. Otherwise, return oldest results first. The default is `false`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `count` | Integer | Number of validation votes returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
+| Field         | Value                           | Description                |
+|:--------------|:--------------------------------|:---------------------------|
+| `result`      | String                          | The value `success` indicates that the body represents a successful response. |
+| `count`       | Integer                         | Number of validation votes returned. |
+| `marker`      | String                          | (May be omitted) [Pagination](#pagination) marker. |
 | `validations` | Array of [Validation Objects][] | The requested validation votes. |
 
 #### Example
@@ -3080,7 +2965,7 @@ Get a single validator's validation vote stats for 24-hour intervals.
 *REST*
 
 ```
-GET /v2/network/validators/{:pubkey}/reports
+GET /v2/network/validators/{pubkey}/reports
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -3089,39 +2974,39 @@ GET /v2/network/validators/{:pubkey}/reports
 
 This method requires the following URL parameters:
 
-| Field     | Value   | Description |
-|-----------|---------|-------------|
-| `pubkey`  | String  | Validator public key. |
+| Field    | Value  | Description           |
+|:---------|:-------|:----------------------|
+| `pubkey` | String | Validator public key. |
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `start` | String - [Timestamp][]  | Start date and time for historical query. Defaults to 200 days before the current date. |
-| `end` | String - [Timestamp][]  | End date and time for historical query. Defaults to most recent data available. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value                  | Description                              |
+|:---------|:-----------------------|:-----------------------------------------|
+| `start`  | String - [Timestamp][] | Start date and time for historical query. The default is to start 200 days before the current date. |
+| `end`    | String - [Timestamp][] | End date and time for historical query. The default is to end with the most recent data available. |
+| `format` | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `count`  | Integer | Number of validators returned. |
+| Field        | Value                                    | Description        |
+|:-------------|:-----------------------------------------|:-------------------|
+| `result`     | String                                   | The value `success` indicates that the body represents a successful response. |
+| `count`      | Integer                                  | Number of validators returned. |
 | `validators` | Array of Single Validator Report Objects | Daily reports of this validator's validation votes. |
 
 Each member in the `validators` array is a Single Validator Report Object with data on that validator's performance on that day. Each has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `date` | String - [Timestamp][] | The start time of the date this object describes. |
-| `total_ledgers` | Integer | Number of ledger hashes for which this validator submitted validation votes. If this number is much lower than other validators in the same time period, that could mean the validator had downtime. |
-| `main_net_agreement` | [String - Number][] | The fraction of consensus-validated production network ledger versions for which this validator voted in this interval. `"1.0"` indicates 100% agreement. |
-| `main_net_ledgers` | Integer | Number of consensus-validated [production network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. |
-| `alt_net_agreement` | [String - Number][] | The fraction of the consensus-validated [Test Network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. `"1.0"` indicates 100% agreement. |
-| `alt_net_ledgers` | Integer | Number of consensus-validated [Test Network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. |
-| `other_ledgers` | Integer | Number of other ledger versions this validator voted for. If this number is high, that could indicate that this validator was running non-standard or out-of-date software. |
+| Field                | Value                  | Description                  |
+|:---------------------|:-----------------------|:-----------------------------|
+| `date`               | String - [Timestamp][] | The start time of the date this object describes. |
+| `total_ledgers`      | Integer                | Number of ledger hashes for which this validator submitted validation votes. If this number is much lower than other validators in the same time period, that could mean the validator had downtime. |
+| `main_net_agreement` | [String - Number][]    | The fraction of consensus-validated production network ledger versions for which this validator voted in this interval. `"1.0"` indicates 100% agreement. |
+| `main_net_ledgers`   | Integer                | Number of consensus-validated [production network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. |
+| `alt_net_agreement`  | [String - Number][]    | The fraction of the consensus-validated [Test Network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. `"1.0"` indicates 100% agreement. |
+| `alt_net_ledgers`    | Integer                | Number of consensus-validated [Test Network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. |
+| `other_ledgers`      | Integer                | Number of other ledger versions this validator voted for. If this number is high, that could indicate that this validator was running non-standard or out-of-date software. |
 
 #### Example
 
@@ -3186,36 +3071,36 @@ GET /v2/network/validator_reports
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `date` | String - [Timestamp][]  | Date and time to query. By default, uses the most recent data available. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field    | Value                  | Description                              |
+|:---------|:-----------------------|:-----------------------------------------|
+| `date`   | String - [Timestamp][] | Date and time to query. By default, uses the most recent data available. |
+| `format` | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that the body represents a successful response. |
-| `count`  | Integer | Number of reports returned. |
+| Field     | Value                                   | Description            |
+|:----------|:----------------------------------------|:-----------------------|
+| `result`  | String                                  | The value `success` indicates that the body represents a successful response. |
+| `count`   | Integer                                 | Number of reports returned. |
 | `reports` | Array of Daily Validator Report Objects | Summaries of activity for each validator active during this time period. |
 
 Daily Validator Report Object fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
+| Field                   | Value                           | Description      |
+|:------------------------|:--------------------------------|:-----------------|
 | `validation_public_key` | String - Base-58 [Public Key][] | This validator's validator public key. |
-| `date` | String - [Timestamp][] | The start time of the date this object describes. |
-| `total_ledgers` | Integer | Number of ledger indexes for which this validator submitted validation votes. If this number is much lower than other validators in the same time period, that could mean the validator had downtime. |
-| `main_net_agreement` | [String - Number][] | The fraction of consensus-validated production network ledger versions for which this validator voted in this interval. `"1.0"` indicates 100% agreement. |
-| `main_net_ledgers` | Integer | Number of consensus-validated [production network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. |
-| `alt_net_agreement` | [String - Number][] | The fraction of the consensus-validated [Test Network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. `"1.0"` indicates 100% agreement. |
-| `alt_net_ledgers` | Integer | Number of consensus-validated [Test Network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. |
-| `other_ledgers` | Integer | Number of other ledger versions this validator voted for. If this number is high, that could indicate that this validator was running non-standard or out-of-date software. |
-| `last_datetime`  | Integer | The last reported validation vote signed by this validator. |
-| `domain` | String | (May be omitted) The DNS domain associated with this validator. |
-| `domain_state` | String | The value `verified` indicates that this validator has a [verified domain](https://developers.ripple.com/run-rippled-as-a-validator.html#domain-verification) controlled by the same operator as the validator. The value `AccountDomainNotFound` indicates that the "Account Domain" part of Domain Verification is not set up properly. The value `RippleTxtNotFound` indicates that the ripple.txt step of Domain Verification is not set up properly. |
+| `date`                  | String - [Timestamp][]          | The start time of the date this object describes. |
+| `total_ledgers`         | Integer                         | Number of ledger indexes for which this validator submitted validation votes. If this number is much lower than other validators in the same time period, that could mean the validator had downtime. |
+| `main_net_agreement`    | [String - Number][]             | The fraction of consensus-validated production network ledger versions for which this validator voted in this interval. `"1.0"` indicates 100% agreement. |
+| `main_net_ledgers`      | Integer                         | Number of consensus-validated [production network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. |
+| `alt_net_agreement`     | [String - Number][]             | The fraction of the consensus-validated [Test Network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. `"1.0"` indicates 100% agreement. |
+| `alt_net_ledgers`       | Integer                         | Number of consensus-validated [Test Network](https://developers.ripple.com/parallel-networks.html) ledger versions this validator voted for. |
+| `other_ledgers`         | Integer                         | Number of other ledger versions this validator voted for. If this number is high, that could indicate that this validator was running non-standard or out-of-date software. |
+| `last_datetime`         | Integer                         | The last reported validation vote signed by this validator. |
+| `domain`                | String                          | (May be omitted) The DNS domain associated with this validator. |
+| `domain_state`          | String                          | The value `verified` indicates that this validator has a [verified domain](https://developers.ripple.com/run-rippled-as-a-validator.html#domain-verification) controlled by the same operator as the validator. The value `AccountDomainNotFound` indicates that the "Account Domain" part of Domain Verification is not set up properly. The value `RippleTxtNotFound` indicates that the ripple.txt step of Domain Verification is not set up properly. |
 
 #### Example
 
@@ -3290,16 +3175,16 @@ GET /v2/network/rippled_versions
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field    | Value                    | Description                           |
-|:---------|:-------------------------|:--------------------------------------|
+| Field    | Value                    | Description                            |
+|:---------|:-------------------------|:---------------------------------------|
 | `result` | String                   | The value `success` indicates that the body represents a successful response. |
-| `count`  | Integer                  | Number of rows returned.              |
+| `count`  | Integer                  | Number of rows returned.               |
 | `rows`   | Array of Version Objects | Description of the latest `rippled` version in each repository. |
 
 Each Version Object contains the following fields:
 
-| Field     | Value                  | Description                            |
-|:----------|:-----------------------|:---------------------------------------|
+| Field     | Value                  | Description                             |
+|:----------|:-----------------------|:----------------------------------------|
 | `date`    | String - [Timestamp][] | The date this `rippled` version was released. |
 | `repo`    | String                 | The Yum repository where this `rippled` is available. The `stable` repository has the latest production version. Other versions are for development and testing. |
 | `version` | String                 | The version string for this version of `rippled`. |
@@ -3368,13 +3253,13 @@ A successful response uses the HTTP code **200 OK** and has a JSON body.
 
 Each field in the top level JSON object is a [Currency Code][]. The content of each field is an array of objects, representing gateways that issue that currency. Each object has the following fields:
 
-| Field    | Value   | Description |
-|----------|---------|-------------|
-| `name` | String  | A human-readable proper name for the gateway. |
-| `account` | String - [Address][] | The [issuing address](https://developers.ripple.com/issuing-and-operational-addresses.html) of this currency. |
-| `featured` | Boolean | Whether this gateway is considered a "featured" issuer of the currency. Ripple decides which gateways to feature based on responsible business practices, volume, and other measures. |
-| `label` | String  | (May be omitted) Only provided when the [Currency Code][] is a 40-character hexadecimal value. This is an alternate human-readable name for the currency issued by this gateway.
-| `assets` | Array of Strings | Graphics filenames available for this gateway, if any. (Mostly, these are logos used by XRP Charts.) |
+| Field      | Value                | Description                              |
+|:-----------|:---------------------|:-----------------------------------------|
+| `name`     | String               | A human-readable proper name for the gateway. |
+| `account`  | String - [Address][] | The [issuing address](https://developers.ripple.com/issuing-and-operational-addresses.html) of this currency. |
+| `featured` | Boolean              | Whether this gateway is considered a "featured" issuer of the currency. Ripple decides which gateways to feature based on responsible business practices, volume, and other measures. |
+| `label`    | String               | (May be omitted) Only provided when the [Currency Code][] is a 40-character hexadecimal value. This is an alternate human-readable name for the currency issued by this gateway. |
+| `assets`   | Array of Strings     | Graphics filenames available for this gateway, if any. (Mostly, these are logos used by XRP Charts.) |
 
 #### Example
 
@@ -3450,7 +3335,7 @@ Get information about a specific gateway from [the Data API's list of known gate
 *REST*
 
 ```
-GET /v2/gateways/{:gateway}
+GET /v2/gateways/{gateway}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -3459,8 +3344,8 @@ GET /v2/gateways/{:gateway}
 
 This method requires the following URL parameters:
 
-| Field | Value | Description |
-|-------|-------|-------------|
+| Field     | Value  | Description                                             |
+|:----------|:-------|:--------------------------------------------------------|
 | `gateway` | String | The issuing [Address][], [URL-encoded name](https://en.wikipedia.org/wiki/Percent-encoding), or normalized name of the gateway. |
 
 This method takes no query parameters.
@@ -3469,21 +3354,21 @@ This method takes no query parameters.
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field       | Value  | Description |
-|-------------|--------|-------------|
-| `name` | String | Human-readable name of the gateway. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `name`       | String                 | Human-readable name of the gateway.  |
 | `start_date` | String - [Timestamp][] | The approximate date of the first time exchanges for this gateway's currencies appeared in the ledger. |
-| `accounts` | Array | A list of [issuing addresses](https://developers.ripple.com/issuing-and-operational-addresses.html) used by this gateway. (Gateways may use different issuing accounts for different currencies.) |
+| `accounts`   | Array                  | A list of [issuing addresses](https://developers.ripple.com/issuing-and-operational-addresses.html) used by this gateway. (Gateways may use different issuing accounts for different currencies.) |
 | `hotwallets` | Array of [Address][]es | This gateway's [operational addresses](https://developers.ripple.com/issuing-and-operational-addresses.html). |
-| `domain` | String | The domain name where this gateway does business. Typically the gateway hosts a [`ripple.txt`](https://wiki.ripple.com/Ripple.txt) there. |
-| `normalized` | String | A normalized version of the `name` field suitable for including in URLs. |
-| `assets` | Array of Strings | Graphics filenames available for this gateway, if any. (Mostly, these are logos used by XRP Charts.) |
+| `domain`     | String                 | The domain name where this gateway does business. Typically the gateway hosts a [`ripple.txt`](https://wiki.ripple.com/Ripple.txt) there. |
+| `normalized` | String                 | A normalized version of the `name` field suitable for including in URLs. |
+| `assets`     | Array of Strings       | Graphics filenames available for this gateway, if any. (Mostly, these are logos used by XRP Charts.) |
 
 Each object in the `accounts` field array has the following fields:
 
-| Field      | Value  | Description |
-|------------|--------|-------------|
-| `address` | String | The [issuing address](https://developers.ripple.com/issuing-and-operational-addresses.html) used by this gateway. |
+| Field        | Value  | Description                                          |
+|:-------------|:-------|:-----------------------------------------------------|
+| `address`    | String | The [issuing address](https://developers.ripple.com/issuing-and-operational-addresses.html) used by this gateway. |
 | `currencies` | Object | Each field in this object is a [Currency Code][] corresponding to a currency issued from this address. Each value is an object with a `featured` boolean indicating whether that currency is featured. Ripple decides which currencies and gateways to feature based on responsible business practices, volume, and other measures. |
 
 #### Example
@@ -3542,15 +3427,15 @@ Retrieve vector icons for various currencies. _(New in [v2.0.4][])_
 *REST*
 
 ```
-GET /v2/currencies/{:currencyimage}
+GET /v2/currencies/{currencyimage}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
 
 This method requires the following URL parameter:
 
-| Field | Value | Description |
-|-------|-------|-------------|
+| Field           | Value  | Description                                       |
+|:----------------|:-------|:--------------------------------------------------|
 | `currencyimage` | String | An image file for a currency, such as `xrp.svg`. See [the source code](https://github.com/ripple/rippled-historical-database/tree/develop/api/gateways/currencyAssets) for a list of available images. |
 
 #### Response Format
@@ -3612,25 +3497,27 @@ GET /v2/accounts
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `start` | String - [Timestamp][]  | Start time of query range. |
-| `end` | String - [Timestamp][]  | End time of query range. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1,000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `descending` | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| `parent` | String  | Filter results to children of the specified parent account. Not compatible with the `interval` parameter. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Start time of query range.           |
+| `end`        | String - [Timestamp][] | End time of query range.             |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1,000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `descending` | Boolean                | If `true`, return results in reverse chronological order. The default is `false`. |
+| `parent`     | String                 | Filter results to children of the specified parent account. Not compatible with the `interval` parameter. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
+
+The `interval` and `reduce` parameters have been removed in [v2.3.5][].
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of accounts returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `accounts` | Array | An array of [account creation objects](#account-creation-objects). |
+| Field      | Value   | Description                                           |
+|:-----------|:--------|:------------------------------------------------------|
+| `result`   | String  | The value `success` indicates that this is a successful response. |
+| `count`    | Integer | Number of accounts returned.                          |
+| `marker`   | String  | (May be omitted) [Pagination](#pagination) marker.    |
+| `accounts` | Array   |An array of [account creation objects](#account-creation-objects). |
 
 #### Example
 
@@ -3690,7 +3577,7 @@ Get creation info for a specific ripple account
 *REST*
 
 ```
-GET /v2/accounts/{:address}
+GET /v2/accounts/{address}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -3699,17 +3586,17 @@ GET /v2/accounts/{:address}
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
+| Field     | Value  | Description                  |
+|:----------|:-------|:-----------------------------|
 | `address` | String | XRP Ledger address to query. |
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
+| Field     | Value                                                  | Description |
+|:----------|:-------------------------------------------------------|:--------|
+| `result`  | String                                                 | The value `success` indicates that this is a successful response. |
 | `account` | Object - [Account Creation](#account-creation-objects) | The requested account. |
 
 #### Example
@@ -3749,7 +3636,7 @@ Get all balances held or owed by a specific XRP Ledger account.
 *REST*
 
 ```
-GET /v2/accounts/{:address}/balances
+GET /v2/accounts/{address}/balances
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -3758,33 +3645,33 @@ GET /v2/accounts/{:address}/balances
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
+| Field     | Value  | Description                  |
+|:----------|:-------|:-----------------------------|
 | `address` | String | XRP Ledger address to query. |
 
 Optionally, you can provide the following query parameters:
 
-| Field        | Value   | Description |
-|--------------|---------|-------------|
-| `ledger_index` | Integer | Index of ledger for historical balances. |
-| `ledger_hash` | String  | Ledger hash for historical balances. |
-| `date` | String  | UTC date for historical balances. |
-| `currency` | String  | Restrict results to specified currency. |
+| Field          | Value   | Description                                       |
+|:---------------|:--------|:--------------------------------------------------|
+| `ledger_index` | Integer | Index of ledger for historical balances.          |
+| `ledger_hash`  | String  | Ledger hash for historical balances.              |
+| `date`         | String  | UTC date for historical balances.                 |
+| `currency`     | String  | Restrict results to specified currency.           |
 | `counterparty` | String  | Restrict results to specified counterparty/issuer. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be greater than 400, but you can use the value `all` to return all results. (Caution: When using limit=all to retrieve very many results, the request may time out. For large issuers, there can be several tens of thousands of results.) |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| `limit`        | Integer | Maximum results per page. The default is 200. Cannot be greater than 400, but you can use the value `all` to return all results. (Caution: When using limit=all to retrieve very many results, the request may time out. For large issuers, there can be several tens of thousands of results.) |
+| `format`       | String  | Format of returned results: `csv` or `json`. The default is `json`. |
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `ledger_index` | Integer | ledger index for balances query. |
-| `close_time` | String | close time of the ledger. |
-| `limit` | String | number of results returned, if limit was exceeded. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `balances` | Array of [Balance Object][]s | The requested balances. |
+| Field          | Value                        | Description                  |
+|:---------------|:-----------------------------|:-----------------------------|
+| `result`       | String                       | The value `success` indicates that this is a successful response. |
+| `ledger_index` | Integer                      | ledger index for balances query. |
+| `close_time`   | String                       | close time of the ledger.    |
+| `limit`        | String                       | number of results returned, if limit was exceeded. |
+| `marker`       | String                       | (May be omitted) [Pagination](#pagination) marker. |
+| `balances`     | Array of [Balance Object][]s | The requested balances.      |
 
 #### Example
 
@@ -3836,7 +3723,7 @@ Get orders in the order books, placed by a specific account. This does not retur
 *REST*
 
 ```
-GET /v2/account/{:address}/orders
+GET /v2/account/{address}/orders
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -3845,45 +3732,45 @@ GET /v2/account/{:address}/orders
 
 This method requires the following URL parameters:
 
-| Field    | Value  | Description |
-|----------|--------|-------------|
+| Field     | Value                | Description                  |
+|:----------|:---------------------|:-----------------------------|
 | `address` | String - [Address][] | XRP Ledger address to query. |
 
 Optionally, you can provide the following query parameters:
 
-| Field         | Value   | Description |
-|---------------|---------|-------------|
-| `ledger_index` | Integer | Get orders as of this ledger. Not compatible with `ledger_hash` or `date`. |
-| `ledger_hash` | String  | Get orders as of this ledger. Not compatible with `ledger_index` or `date`. |
-| `date` | String - [Timestamp][] | Get orders at this time. Not compatible with `ledger_index` or `ledger_hash`. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be greater than 400. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field          | Value                  | Description                        |
+|:---------------|:-----------------------|:-----------------------------------|
+| `ledger_index` | Integer                | Get orders as of this ledger. Not compatible with `ledger_hash` or `date`. |
+| `ledger_hash`  | String                 | Get orders as of this ledger. Not compatible with `ledger_index` or `date`. |
+| `date`         | String - [Timestamp][] | Get orders at this time. Not compatible with `ledger_index` or `ledger_hash`. |
+| `limit`        | Integer                | Maximum results per page. The default is 200. Cannot be greater than 400. |
+| `format`       | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 If none of `ledger_index`, `ledger_hash`, or `date` are specified, the API uses the most current data available.
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `ledger_index` | Integer | `ledger_index` of the ledger version used. |
-| `close_time` | String | Close time of the ledger version used. |
-| `limit` | String | The `limit` from the request. |
-| `orders` | Array of order objects | The requested orders. |
+| Field          | Value                  | Description                        |
+|:---------------|:-----------------------|:-----------------------------------|
+| `result`       | String                 | The value `success` indicates that this is a successful response. |
+| `ledger_index` | Integer                | `ledger_index` of the ledger version used. |
+| `close_time`   | String                 | Close time of the ledger version used. |
+| `limit`        | String                 | The `limit` from the request.      |
+| `orders`       | Array of order objects | The requested orders.              |
 
 Each order object has the following fields:
 
-| Field                        | Value  | Description |
-|------------------------------|--------|-------------|
-| `specification` | Object | Details of this order's current state. |
-| `specification.direction` | String | Either `buy` or `sell`. |
-| `specification.quantity` | [Balance Object][] | The maximum amount of the base currency this order would buy or sell (depending on the direction). This value decreases as the order gets partially filled. |
-| `specification.totalPrice` | [Balance Object][] | The maximum amount of the counter currency the order can spend or gain to buy or sell the base currency. This value decreases as the order gets partially filled. |
-| `properties` | Object | Details of how the order was placed. |
-| `properties.maker` | String - [Address][] | The XRP Ledger account that placed the order. |
-| `properties.sequence` | Number | The sequence number of the transaction that placed this order. |
-| `properties.makerExchangeRate` | [String - Number][] | The exchange rate from the point of view of the account that submitted the order. |
+| Field                          | Value                | Description          |
+|:-------------------------------|:---------------------|:---------------------|
+| `specification`                | Object               | Details of this order's current state. |
+| `specification.direction`      | String               | Either `buy` or `sell`. |
+| `specification.quantity`       | [Balance Object][]   | The maximum amount of the base currency this order would buy or sell (depending on the direction). This value decreases as the order gets partially filled. |
+| `specification.totalPrice`     | [Balance Object][]   | The maximum amount of the counter currency the order can spend or gain to buy or sell the base currency. This value decreases as the order gets partially filled. |
+| `properties`                   | Object               | Details of how the order was placed. |
+| `properties.maker`             | String - [Address][] | The XRP Ledger account that placed the order. |
+| `properties.sequence`          | Number               | The sequence number of the transaction that placed this order. |
+| `properties.makerExchangeRate` | [String - Number][]  | The exchange rate from the point of view of the account that submitted the order. |
 
 #### Example
 
@@ -3962,7 +3849,7 @@ Retrieve a history of transactions that affected a specific account. This includ
 *REST*
 
 ```
-GET /v2/accounts/{:address}/transactions
+GET /v2/accounts/{address}/transactions
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -3971,25 +3858,25 @@ GET /v2/accounts/{:address}/transactions
 
 This method requires the following URL parameters:
 
-| Field    | Value  | Description |
-|----------|--------|-------------|
-| :address | String - [Address][] | XRP Ledger address to query. |
+| Field     | Value                | Description                  |
+|:----------|:---------------------|:-----------------------------|
+| `address` | String - [Address][] | XRP Ledger address to query. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field        | Value   | Description |
-|--------------|---------|-------------|
-| `start` | String - [Timestamp][] | Start time of query range. Defaults to the earliest date available. |
-| `end` | String - [Timestamp][]  | End time of query range. Defaults to the current date. |
-| `min_sequence` | String  | Minimum sequence number to query. |
-| `max_sequence` | String  | Max sequence number to query. |
-| `type` | String  | Restrict results to a specified [transaction type](https://developers.ripple.com/transaction-types.html) |
-| `result` | String  | Restrict results to a specified [transaction result](https://developers.ripple.com/transaction-results.html). |
-| `binary` | Boolean | Return results in binary format. |
-| `descending` | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| `limit` | Integer | Maximum results per page. Defaults to 20. Cannot be more than 1,000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
+| Field          | Value                  | Description                        |
+|:---------------|:-----------------------|:-----------------------------------|
+| `start`        | String - [Timestamp][] | Start time of query range. The default is the earliest date available. |
+| `end`          | String - [Timestamp][] | End time of query range. The default is the current date. |
+| `min_sequence` | String                 | Minimum sequence number to query.  |
+| `max_sequence` | String                 | Max sequence number to query.      |
+| `type`         | String                 | Restrict results to a specified [transaction type](https://developers.ripple.com/transaction-types.html). |
+| `result`       | String                 | Restrict results to a specified [transaction result](https://developers.ripple.com/transaction-results.html). |
+| `binary`       | Boolean                | Return results in binary format.   |
+| `descending`   | Boolean                | If `true`, return results in reverse chronological order. The default is `false`. |
+| `limit`        | Integer                | Maximum results per page. The default is 20. Cannot be more than 1,000. |
+| `marker`       | String                 | [Pagination](#pagination) key from previously returned response. |
 
 **Note:** This method cannot return CSV format; only JSON results are supported for raw XRP Ledger transactions.
 
@@ -3998,11 +3885,11 @@ Optionally, you can provide the following query parameters:
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | The number of objects contained in the `transactions` field. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
+| Field          | Value                                                | Description |
+|:---------------|:-----------------------------------------------------|:-----|
+| `result`       | String                                               | The value `success` indicates that this is a successful response. |
+| `count`        | Integer                                              | The number of objects contained in the `transactions` field. |
+| `marker`       | String                                               | (May be omitted) [Pagination](#pagination) marker. |
 | `transactions` | Array of [transaction objects](#transaction-objects) | All transactions matching the request. |
 
 #### Example
@@ -4094,7 +3981,7 @@ Retrieve a specifc transaction originating from a specified account
 *REST*
 
 ```
-GET /v2/accounts/{:address}/transactions/{:sequence}
+GET /v2/accounts/{address}/transactions/{sequence}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -4103,26 +3990,26 @@ GET /v2/accounts/{:address}/transactions/{:sequence}
 
 This method requires the following URL parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
+| Field      | Value   | Description                  |
+|:-----------|:--------|:-----------------------------|
 | `address`  | String  | XRP Ledger address to query. |
 | `sequence` | Integer | Transaction sequence number. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field  | Value   | Description |
-|--------|---------|-------------|
-| `binary` | Boolean | If `true`, return transaction in binary format. Defaults to `false`. |
+| Field    | Value   | Description                                             |
+|:---------|:--------|:--------------------------------------------------------|
+| `binary` | Boolean | If `true`, return transaction in binary format. The default is `false`. |
 
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
+| Field         | Value                                      | Description     |
+|:--------------|:-------------------------------------------|:----------------|
+| `result`      | String                                     | The value `success` indicates that this is a successful response. |
 | `transaction` | [transaction object](#transaction-objects) | The requested transaction. |
 
 #### Example
@@ -4163,7 +4050,7 @@ Retrieve a payments for a specified account
 *REST*
 
 ```
-GET /v2/accounts/{:address}/payments
+GET /v2/accounts/{address}/payments
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -4172,36 +4059,36 @@ GET /v2/accounts/{:address}/payments
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
+| Field     | Value  | Description                  |
+|:----------|:-------|:-----------------------------|
 | `address` | String | XRP Ledger address to query. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `start` | String - [Timestamp][]  | Filter results to this time and later. |
-| `end` | String - [Timestamp][]  | Filter results to this time and earlier. |
-| `type` | String  | Type of payment - `sent` or `received`. |
-| `currency` | String - [Currency Code][] | Filter results to specified currency. |
-| `issuer` | String - [Address][] | Filter results to specified issuer. |
-| `source_tag` | Integer | Filter results to specified source tag. |
-| `destination_tag` | Integer | Filter results to specified destination tag. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1,000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field             | Value                      | Description                 |
+|:------------------|:---------------------------|:----------------------------|
+| `start`           | String - [Timestamp][]     | Filter results to this time and later. |
+| `end`             | String - [Timestamp][]     | Filter results to this time and earlier. |
+| `type`            | String                     | Type of payment - `sent` or `received`. |
+| `currency`        | String - [Currency Code][] | Filter results to specified currency. |
+| `issuer`          | String - [Address][]       | Filter results to specified issuer. |
+| `source_tag`      | Integer                    | Filter results to specified source tag. |
+| `destination_tag` | Integer                    | Filter results to specified destination tag. |
+| `limit`           | Integer                    | Maximum results per page. The default is 200. Cannot be more than 1,000. |
+| `marker`          | String                     | [Pagination](#pagination) key from previously returned response. |
+| `format`          | String                     | Format of returned results: `csv` or `json`. The default is `json`. |
 
 
 #### Response Format
 
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | The number of objects contained in the `payments` field. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
+| Field      | Value                        | Description                      |
+|:-----------|:-----------------------------|:---------------------------------|
+| `result`   | String                       | The value `success` indicates that this is a successful response. |
+| `count`    | Integer                      | The number of objects contained in the `payments` field. |
+| `marker`   | String                       | (May be omitted) [Pagination](#pagination) marker. |
 | `payments` | Array of [payment objects][] | All payments matching the request, sorted with oldest first. |
 
 #### Example
@@ -4270,13 +4157,13 @@ There are two variations on this method:
 *REST - All Exchanges*
 
 ```
-GET /v2/accounts/{:address}/exchanges/
+GET /v2/accounts/{address}/exchanges/
 ```
 
 *REST - Specific Currency Pair*
 
 ```
-GET /v2/accounts/{:address}/exchanges/{:base}/{:counter}
+GET /v2/accounts/{address}/exchanges/{base}/{counter}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -4285,34 +4172,34 @@ GET /v2/accounts/{:address}/exchanges/{:base}/{:counter}
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
-| `address` | String | XRP Ledger address to query. |
+| Field     | Value  | Description                                             |
+|:----------|:-------|:--------------------------------------------------------|
+| `address` | String | XRP Ledger address to query.                            |
 | `base`    | String | Base currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
 | `counter` | String | Counter currency of the pair, as a [Currency Code][], followed by `+` and the issuer [Address][] unless it's XRP. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `start` | String - [Timestamp][]  | Filter results to this time and later. |
-| `end` | String - [Timestamp][]  | Filter results to this time and earlier. |
-| `descending` | Boolean | If true, return results in reverse chronological order. Defaults to false. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Filter results to this time and later. |
+| `end`        | String - [Timestamp][] | Filter results to this time and earlier. |
+| `descending` | Boolean                | If `true`, return results in reverse chronological order. The default is `false`. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of exchanges returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
-| `exchanges` | Array of [Exchange Objects][] | The requested exchanges. |
+| Field       | Value                         | Description                    |
+|:------------|:------------------------------|:-------------------------------|
+| `result`    | String                        | The value `success` indicates that this is a successful response. |
+| `count`     | Integer                       | Number of exchanges returned.  |
+| `marker`    | String                        | (May be omitted) [Pagination](#pagination) marker. |
+| `exchanges` | Array of [Exchange Objects][] | The requested exchanges.       |
 
 #### Example
 
@@ -4388,7 +4275,7 @@ Retrieve Balance changes for a given account over time.
 *REST*
 
 ```
-GET /v2/accounts/{:address}/balance_changes/
+GET /v2/accounts/{address}/balance_changes/
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -4397,33 +4284,33 @@ GET /v2/accounts/{:address}/balance_changes/
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
+| Field     | Value  | Description                  |
+|:----------|:-------|:-----------------------------|
 | `address` | String | XRP Ledger address to query. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `currency` | String  | Restrict results to specified currency. |
-| `counterparty` | String  | Restrict results to specified counterparty/issuer. |
-| `start` | String - [Timestamp][]  | Start time of query range. |
-| `end` | String - [Timestamp][]  | End time of query range. |
-| `descending` | Boolean | If `true`, return results in reverse chronological order. Defaults to `false`. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `format` | String  | Format of returned results: `csv` or`json`. Defaults to `json`. |
+| Field          | Value                  | Description                        |
+|:---------------|:-----------------------|:-----------------------------------|
+| `currency`     | String                 | Restrict results to specified currency. |
+| `counterparty` | String                 | Restrict results to specified counterparty/issuer. |
+| `start`        | String - [Timestamp][] | Start time of query range.         |
+| `end`          | String - [Timestamp][] | End time of query range.           |
+| `descending`   | Boolean                | If `true`, return results in reverse chronological order. The default is `false`. |
+| `limit`        | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`       | String                 | [Pagination](#pagination) key from previously returned response. |
+| `format`       | String                 | Format of returned results: `csv` or`json`. The default is `json`. |
 
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of balance changes returned. |
-| `marker` | String | (May be omitted) [Pagination](#pagination) marker. |
+| Field       | Value                                   | Description          |
+|:------------|:----------------------------------------|:---------------------|
+| `result`    | String                                  | The value `success` indicates that this is a successful response. |
+| `count`     | Integer                                 | Number of balance changes returned. |
+| `marker`    | String                                  | (May be omitted) [Pagination](#pagination) marker. |
 | `exchanges` | Array of [balance change descriptors][] | The requested balance changes. |
 
 #### Example
@@ -4491,13 +4378,13 @@ Retrieve daily summaries of payment activity for an account.
 *REST - Date Omitted*
 
 ```
-GET /v2/accounts/{:address}/reports/
+GET /v2/accounts/{address}/reports/
 ```
 
 *REST - Date Specified*
 
 ```
-GET /v2/accounts/{:address}/reports/{:date}
+GET /v2/accounts/{address}/reports/{date}
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -4506,31 +4393,31 @@ GET /v2/accounts/{:address}/reports/{:date}
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
-| `address` | String | XRP Ledger address to query. |
-| `date`    | String | (Optional) UTC date for single report. If omitted, use the `start` and `end` query parameters. |
+| Field     | Value  | Description                                             |
+|:----------|:-------|:--------------------------------------------------------|
+| `address` | String | XRP Ledger address to query.                            |
+| `date`    | String | _(Optional)_ UTC date for single report. If omitted, use the `start` and `end` query parameters. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `start` | String - [Timestamp][] | Start time of query range. Defaults to start of current date. Ignored if `date` specified. |
-| `end` | String - [Timestamp][] | End time of query range. Defaults to current date. Ignored if `date` specified. |
-| `accounts` | Boolean | If true, provide lists with addresses of all `sending_counterparties` and `receiving_counterparties` in results. Otherwise, return only the number of sending and receiving counterparties. |
-| `payments` | Boolean | Include [Payment Summary Objects][] in the `payments` field for each interval, with the payments that occurred during that interval. |
-| `descending` | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Start time of query range. The default is the start of the current date. Ignored if `date` specified. |
+| `end`        | String - [Timestamp][] | End time of query range. The default is the end of the current date. Ignored if `date` specified. |
+| `accounts`   | Boolean                | If `true`, provide lists with addresses of all `sending_counterparties` and `receiving_counterparties` in results. Otherwise, return only the number of sending and receiving counterparties. The default is `false`. |
+| `payments`   | Boolean                | Include [Payment Summary Objects][] in the `payments` field for each interval, with the payments that occurred during that interval. |
+| `descending` | Boolean                | If `true`, sort results with most recent first. By default, sort results with oldest first. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of reports in the `reports` field. |
+| Field     | Value                        | Description                       |
+|:----------|:-----------------------------|:----------------------------------|
+| `result`  | String                       | The value `success` indicates that this is a successful response. |
+| `count`   | Integer                      | Number of reports in the `reports` field. |
 | `reports` | Array of [Reports Objects][] | Daily summaries of account activity for the given account and date range. |
 
 #### Example
@@ -4604,7 +4491,7 @@ Retrieve daily summaries of transaction activity for an account. _(New in [v2.1.
 *REST*
 
 ```
-GET /v2/accounts/{:address}/stats/transactions
+GET /v2/accounts/{address}/stats/transactions
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -4613,40 +4500,40 @@ GET /v2/accounts/{:address}/stats/transactions
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
+| Field     | Value  | Description                  |
+|:----------|:-------|:-----------------------------|
 | `address` | String | XRP Ledger address to query. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `start` | String - [Timestamp][] | Start time of query range. Defaults to the earliest date available. |
-| `end` | String - [Timestamp][] | End time of query range. Defaults to the current date. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `descending` | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Start time of query range. The default is the earliest date available. |
+| `end`        | String - [Timestamp][] | End time of query range. The default is the current date. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `descending` | Boolean                | If `true`, sort results with most recent first. By default, sort results with oldest first. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of transaction stats objects in the `rows` field. |
-| `rows` | Array of Transaction Stats Objects | Daily summaries of account transaction activity for the given account. |
+| Field    | Value                              | Description                  |
+|:---------|:-----------------------------------|:-----------------------------|
+| `result` | String                             | The value `success` indicates that this is a successful response. |
+| `count`  | Integer                            | Number of transaction stats objects in the `rows` field. |
+| `rows`   | Array of Transaction Stats Objects | Daily summaries of account transaction activity for the given account. |
 
 Each Transaction Stats Object has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `date` | String - [Timestamp][] | This object describes activity on this date. |
-| `transaction_count` | Integer | The total number of transactions sent by the account on this date. |
-| `result` | Object | Map of [transaction result codes](https://developers.ripple.com/transaction-results.html), indicating how many of each result code occurred in the transactions sent by this account on this date. |
-| `type` | Object | Map of [transaction types](https://developers.ripple.com/transaction-formats.html), indicating how many of each transaction type the account sent on this date. |
+| Field               | Value                  | Description                   |
+|:--------------------|:-----------------------|:------------------------------|
+| `date`              | String - [Timestamp][] | This object describes activity on this date. |
+| `transaction_count` | Integer                | The total number of transactions sent by the account on this date. |
+| `result`            | Object                 | Map of [transaction result codes](https://developers.ripple.com/transaction-results.html), indicating how many of each result code occurred in the transactions sent by this account on this date. |
+| `type`              | Object                 | Map of [transaction types](https://developers.ripple.com/transaction-formats.html), indicating how many of each transaction type the account sent on this date. |
 
 #### Example
 
@@ -4703,7 +4590,7 @@ Retrieve daily summaries of transaction activity for an account. _(New in [v2.1.
 *REST*
 
 ```
-GET /v2/accounts/{:address}/stats/value
+GET /v2/accounts/{address}/stats/value
 ```
 
 <!-- MULTICODE_BLOCK_END -->
@@ -4712,39 +4599,39 @@ GET /v2/accounts/{:address}/stats/value
 
 This method requires the following URL parameters:
 
-| Field     | Value  | Description |
-|-----------|--------|-------------|
+| Field     | Value  | Description                  |
+|:----------|:-------|:-----------------------------|
 | `address` | String | XRP Ledger address to query. |
 
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `start` | String - [Timestamp][] | Start time of query range. Defaults to the start of the most recent interval. |
-| `end` | String - [Timestamp][] | End time of query range. Defaults to the end of the most recent interval. |
-| `limit` | Integer | Maximum results per page. Defaults to 200. Cannot be more than 1000. |
-| `marker` | String  | [Pagination](#pagination) key from previously returned response. |
-| `descending` | Boolean | If true, sort results with most recent first. By default, sort results with oldest first. |
-| `format` | String  | Format of returned results: `csv` or `json`. Defaults to `json`. |
+| Field        | Value                  | Description                          |
+|:-------------|:-----------------------|:-------------------------------------|
+| `start`      | String - [Timestamp][] | Start time of query range. The default is the start of the most recent interval. |
+| `end`        | String - [Timestamp][] | End time of query range. The default is the end of the most recent interval. |
+| `limit`      | Integer                | Maximum results per page. The default is 200. Cannot be more than 1000. |
+| `marker`     | String                 | [Pagination](#pagination) key from previously returned response. |
+| `descending` | Boolean                | If `true`, sort results with most recent first. By default, sort results with oldest first. |
+| `format`     | String                 | Format of returned results: `csv` or `json`. The default is `json`. |
 
 
 #### Response Format
 A successful response uses the HTTP code **200 OK** and has a JSON body with the following:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `result` | String | The value `success` indicates that this is a successful response. |
-| `count` | Integer | Number of value stats objects in the `rows` field. |
-| `rows` | Array of Value Stats Objects | Daily summaries of account value for the given account. |
+| Field    | Value                        | Description                        |
+|:---------|:-----------------------------|:-----------------------------------|
+| `result` | String                       | The value `success` indicates that this is a successful response. |
+| `count`  | Integer                      | Number of value stats objects in the `rows` field. |
+| `rows`   | Array of Value Stats Objects | Daily summaries of account value for the given account. |
 
 Each Value Stats Object has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `date` | String - [Timestamp][] | This object describes activity on this date. |
-| `value` | [String - Number][] | The total of all currency held by this account, normalized to XRP. |
-| `balance_change_count` | Number | The number of times the account's balance changed on this date. |
+| Field                  | Value                  | Description                |
+|:-----------------------|:-----------------------|:---------------------------|
+| `date`                 | String - [Timestamp][] | This object describes activity on this date. |
+| `value`                | [String - Number][]    | The total of all currency held by this account, normalized to XRP. |
+| `balance_change_count` | Number                 | The number of times the account's balance changed on this date. |
 
 #### Example
 
@@ -4799,10 +4686,10 @@ GET /v2/health/api
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `threshold` | Integer  | Consider the API unhealthy if the database does not respond within this amount of time, in seconds. Defaults to 5 seconds. |
-| `verbose` | Boolean | If true, return a JSON response with data points. By default, return an integer value only. |
+| Field       | Value   | Description                                          |
+|:------------|:--------|:-----------------------------------------------------|
+| `threshold` | Integer | Consider the API unhealthy if the database does not respond within this amount of time, in seconds. The default is 5 seconds. |
+| `verbose`   | Boolean | If `true`, return a JSON response with data points. By default, return an integer value only. |
 
 #### Response Format
 
@@ -4810,17 +4697,17 @@ A successful response uses the HTTP code **200 OK**. By default, the response bo
 
 The health value `0` always indicates a healthy status. Other health values are defined as follows:
 
-| Value | Meaning |
-|-------|---------|
+| Value | Meaning                                                              |
+|:------|:---------------------------------------------------------------------|
 | `0`   | API service is up, and response time to HBase is less than `threshold` value from request. |
 | `1`   | API service is up, but response time to HBase is greater than `threshold` value from request. |
 
 If the request specifies `verbose=true` in the query parameters, the response body is a JSON object, with the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `score` | 0-1 | Health value, as defined above. |
-| `response_time` | String - Human-readable time | The actual response time of the database. |
+| Field                     | Value                        | Description       |
+|:--------------------------|:-----------------------------|:------------------|
+| `score`                   | 0-1                          | Health value, as defined above. |
+| `response_time`           | String - Human-readable time | The actual response time of the database. |
 | `response_time_threshold` | String - Human-readable time | The maximum response time to be considered healthy. |
 
 #### Example
@@ -4862,11 +4749,11 @@ GET /v2/health/importer
 
 Optionally, you can provide the following query parameters:
 
-| Field      | Value   | Description |
-|------------|---------|-------------|
-| `threshold` | Integer | Consider the Importer unhealthy if more than this amount of time, in seconds, has elapsed since the latest validated ledger was imported. Defaults to 300 seconds. |
-| `threshold2` | Integer | Consider the Importer unhealthy if more than this amount of time, in seconds, has elapsed since the latest ledger of any kind was imported. Defaults to 60 seconds. |
-| `verbose` | Boolean | If true, return a JSON response with data points. By default, return an integer value only. |
+| Field        | Value   | Description                                         |
+|:-------------|:--------|:----------------------------------------------------|
+| `threshold`  | Integer | Consider the Importer unhealthy if more than this amount of time, in seconds, has elapsed since the latest validated ledger was imported. The default is 300 seconds. |
+| `threshold2` | Integer | Consider the Importer unhealthy if more than this amount of time, in seconds, has elapsed since the latest ledger of any kind was imported. The default is 60 seconds. |
+| `verbose`    | Boolean | If `true`, return a JSON response with data points. By default, return an integer value only. |
 
 #### Response Format
 
@@ -4874,21 +4761,21 @@ A successful response uses the HTTP code **200 OK**. By default, the response bo
 
 The health value `0` always indicates a healthy status. Other health values are defined as follows:
 
-| Value | Meaning |
-|-------|---------|
+| Value | Meaning                                                              |
+|:------|:---------------------------------------------------------------------|
 | `0`   | The most recent imported ledger was less than `threshold2` (Default: 60) seconds ago, and most recent validated ledger was less than `threshold` seconds ago. |
 | `1`   | The most recent imported ledger was less than `threshold2` (Default: 60) seconds ago, but the most recent validated ledger is older than `threshold` seconds. |
 | `2`   | The most recent imported ledger was more than `threshold2` seconds ago. |
 
 If the request specifies `verbose=true` in the query parameters, the response body is a JSON object, with the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `score` | 0-2 | Health value, as defined above. |
-| `response_time` | String | The actual response time of the database. |
-| `ledger_gap` | String - Human-readable time | Difference between the close time of the last saved ledger and the current time. |
-| `ledger_gap_threshold` | String - Human-readable time | Maximum ledger gap to be considered healthy. |
-| `valildation_gap` | String - Human-readable time | Difference between the close time of the last imported validated ledger and the current time. |
+| Field                      | Value                        | Description      |
+|:---------------------------|:-----------------------------|:-----------------|
+| `score`                    | 0-2                          | Health value, as defined above. |
+| `response_time`            | String                       | The actual response time of the database. |
+| `ledger_gap`               | String - Human-readable time | Difference between the close time of the last saved ledger and the current time. |
+| `ledger_gap_threshold`     | String - Human-readable time | Maximum ledger gap to be considered healthy. |
+| `valildation_gap`          | String - Human-readable time | Difference between the close time of the last imported validated ledger and the current time. |
 | `validation_gap_threshold` | String - Human-readable time | Maximum validation gap to be considered healthy. |
 
 #### Example
@@ -4934,9 +4821,9 @@ GET /v2/health/nodes_etl
 
 Optionally, you can provide the following query parameters:
 
-| Field       | Value   | Description |
-|-------------|---------|-------------|
-| `threshold` | Integer | Consider the service unhealthy if more than this amount of time, in seconds, has elapsed since the latest data was imported. Defaults to 120 seconds. |
+| Field       | Value   | Description                                          |
+|:------------|:--------|:-----------------------------------------------------|
+| `threshold` | Integer | Consider the service unhealthy if more than this amount of time, in seconds, has elapsed since the latest data was imported. The default is 120 seconds. |
 | `verbose`   | Boolean | If `true`, return a JSON response with data points. By default, return an integer value only. |
 
 #### Response Format
@@ -4945,20 +4832,20 @@ A successful response uses the HTTP code **200 OK**. By default, the response bo
 
 The health value `0` always indicates a healthy status. Other health values are defined as follows:
 
-| Value | Meaning |
-|-------|---------|
+| Value | Meaning                                                              |
+|:------|:---------------------------------------------------------------------|
 | `0`   | The most recent imported topology data was less than `threshold` (Default: 120) seconds ago. |
 | `1`   | The most recent imported topology data was more than `threshold` seconds ago. |
 
 
 If the request specifies `verbose=true` in the query parameters, the response body is a JSON object, with the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `score` | 0-1 | Health value, as defined above. |
-| `gap` | String - Human-readable time | Difference between the latest imported data and the current time. |
+| Field           | Value                        | Description                 |
+|:----------------|:-----------------------------|:----------------------------|
+| `score`         | 0-1                          | Health value, as defined above. |
+| `gap`           | String - Human-readable time | Difference between the latest imported data and the current time. |
 | `gap_threshold` | String - Human-readable time | Maximum gap to be considered healthy. |
-| `message` | String | Description of the reason for a non-zero score, if applicable. |
+| `message`       | String                       | Description of the reason for a non-zero score, if applicable. |
 
 #### Example
 
@@ -5000,10 +4887,10 @@ GET /v2/health/validations_etl
 
 Optionally, you can provide the following query parameters:
 
-| Field       | Value   | Description |
-|-------------|---------|-------------|
-| `threshold` | Integer | Consider the service unhealthy if more than this amount of time, in seconds, has elapsed since the latest data was imported. Defaults to 120 seconds. |
-| `verbose`   | Boolean | If true, return a JSON response with data points. By default, return an integer value only. |
+| Field       | Value   | Description                                          |
+|:------------|:--------|:-----------------------------------------------------|
+| `threshold` | Integer | Consider the service unhealthy if more than this amount of time, in seconds, has elapsed since the latest data was imported. The default is 120 seconds. |
+| `verbose`   | Boolean | If `true`, return a JSON response with data points. By default, return an integer value only. |
 
 #### Response Format
 
@@ -5011,19 +4898,19 @@ A successful response uses the HTTP code **200 OK**. By default, the response bo
 
 The health value `0` always indicates a healthy status. Other health values are defined as follows:
 
-| Value | Meaning |
-|-------|---------|
+| Value | Meaning                                                              |
+|:------|:---------------------------------------------------------------------|
 | `0`   | The most recent imported topology data was less than `threshold` (Default: 120) seconds ago. |
 | `1`   | The most recent imported topology data was more than `threshold` seconds ago. |
 
 If the request specifies `verbose=true` in the query parameters, the response body is a JSON object, with the following fields:
 
-| Field     | Value | Description |
-|-----------|-------|-------------|
-| `score`   | 0-1 | Health value, as defined above. |
-| `gap`     | String - Human-readable time | Difference between the latest imported data and the current time. |
+| Field           | Value                        | Description                 |
+|:----------------|:-----------------------------|:----------------------------|
+| `score`         | 0-1                          | Health value, as defined above. |
+| `gap`           | String - Human-readable time | Difference between the latest imported data and the current time. |
 | `gap_threshold` | String - Human-readable time | Maximum gap to be considered healthy. |
-| `message` | String | Description of the reason for a non-zero score, if applicable. |
+| `message`       | String                       | Description of the reason for a non-zero score, if applicable. |
 
 #### Example
 
@@ -5188,39 +5075,39 @@ Transactions have two formats - a compact "binary" format where the defining fie
 
 ### Full JSON Format
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `hash`  | String - [Hash][] | An identifying hash value unique to this transaction, as a hex string. |
-| `date`  | String - [Timestamp][] | The time when this transaction was included in a validated ledger. |
+| Field          | Value                     | Description                     |
+|:---------------|:--------------------------|:--------------------------------|
+| `hash`         | String - [Hash][]         | An identifying hash value unique to this transaction, as a hex string. |
+| `date`         | String - [Timestamp][]    | The time when this transaction was included in a validated ledger. |
 | `ledger_index` | Number - [Ledger Index][] | The sequence number of the ledger that included this ledger. |
-| `tx`    | Object | The fields of this transaction object, as defined by the [Transaction Format](https://developers.ripple.com/transaction-formats.html) |
-| `meta`  | Object | Metadata about the results of this transaction. |
+| `tx`           | Object                    | The fields of this transaction object, as defined by the [Transaction Format](https://developers.ripple.com/transaction-formats.html). |
+| `meta`         | Object                    | Metadata about the results of this transaction. |
 
 ### Binary Format
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `hash`  | String - [Hash][] | An identifying hash value unique to this transaction, as a hex string. |
-| `date`  | String - [Timestamp][] | The time when this transaction was included in a validated ledger. |
+| Field          | Value                     | Description                     |
+|:---------------|:--------------------------|:--------------------------------|
+| `hash`         | String - [Hash][]         | An identifying hash value unique to this transaction, as a hex string. |
+| `date`         | String - [Timestamp][]    | The time when this transaction was included in a validated ledger. |
 | `ledger_index` | Number - [Ledger Index][] | The sequence number of the ledger that included this ledger. |
-| `tx`    | String | The binary data that represents this transaction, as a hexadecimal string. |
-| `meta`  | String | The binary data that represents this transaction's metadata, as a hex string. |
+| `tx`           | String                    | The binary data that represents this transaction, as a hexadecimal string. |
+| `meta`         | String                    | The binary data that represents this transaction's metadata, as a hex string. |
 
 ## Ledger Objects
 
 A "ledger" is one version of the shared global ledger. Each ledger object has the following fields:
 
-| Field        | Value | Description |
-|--------------|-------|-------------|
-| `ledger_hash`  | String - [Hash][] | An identifying hash unique to this ledger, as a hex string. |
-| `ledger_index` | Number - [Ledger Index][] | The sequence number of the ledger. Each new ledger has a ledger index 1 higher than the ledger that came before it. |
-| `parent_hash`  | String - [Hash][] | The identifying hash of the previous ledger. |
-| `total_coins`  | [String - Number][] | The total number of "drops" of XRP still in existence at the time of the ledger. (Each XRP is 1,000,000 drops.) |
-| `close_time_res` | Number | The ledger close time is rounded to this many seconds. |
-| `accounts_hash` | String - [Hash][] | Hash of the account information contained in this ledger, as hex. |
-| `transactions_hash` | String - [Hash][] | Hash of the transaction information contained in this ledger, as hex. |
-| `close_time` | Number | When this ledger was closed, in UNIX time. |
-| `close_time_human` | String - [Timestamp][] | When this ledger was closed. |
+| Field               | Value                     | Description                |
+|:--------------------|:--------------------------|:---------------------------|
+| `ledger_hash`       | String - [Hash][]         | An identifying hash unique to this ledger, as a hex string. |
+| `ledger_index`      | Number - [Ledger Index][] | The sequence number of the ledger. Each new ledger has a ledger index 1 higher than the ledger that came before it. |
+| `parent_hash`       | String - [Hash][]         | The identifying hash of the previous ledger. |
+| `total_coins`       | [String - Number][]       | The total number of "drops" of XRP still in existence at the time of the ledger. (Each XRP is 1,000,000 drops.) |
+| `close_time_res`    | Number                    | The ledger close time is rounded to this many seconds. |
+| `accounts_hash`     | String - [Hash][]         | Hash of the account information contained in this ledger, as hex. |
+| `transactions_hash` | String - [Hash][]         | Hash of the transaction information contained in this ledger, as hex. |
+| `close_time`        | Number                    | When this ledger was closed, in UNIX time. |
+| `close_time_human`  | String - [Timestamp][]    | When this ledger was closed. |
 
 **Note:** Ledger close times are approximate, typically rounded to about 10 seconds. Two ledgers could have the same `close_time` values, when their actual close times were several seconds apart. The sequence number (`ledger_index`) of the ledger makes it unambiguous which ledger closed first.
 
@@ -5232,16 +5119,16 @@ Due to a mishap early in the XRP Ledger's history, ledgers 1 through 32569 were 
 
 An account creation object represents the action of creating an account in the XRP Ledger. There are two variations, depending on whether the account was already present in ledger 32570, the earliest ledger available. Accounts that were already present in ledger 32570 are termed _genesis accounts_.
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `address` | String - [Address][] | The identifying address of this account, in base-58. |
-| `inception` | String - [Timestamp][] | The UTC timestamp when the address was funded. For genesis accounts, this is the timestamp of ledger 32570. |
-| `ledger_index` | Number - [Ledger Index][] | The sequence number of the ledger when the account was created, or 32570 for genesis accounts. |
-| `parent` | String - [Address][] | (Omitted for genesis accounts) The address that provided the XRP to fund this address. |
-| `tx_hash` | String - [Hash][] | (Omitted for genesis accounts) The identifying hash of the transaction that funded this account. |
-| `initial_balance` | [String - Number][] | (Omitted for genesis accounts) The amount of XRP that funded this account. |
-| `genesis_balance` | [String - Number][] | (Genesis accounts only) The amount of XRP this account held as of ledger #32570. |
-| `genesis_index` | Number - [Sequence Number][] | (Genesis accounts only) The transaction sequence number of the account as of ledger #32570. |
+| Field             | Value                        | Description               |
+|:------------------|:-----------------------------|:--------------------------|
+| `address`         | String - [Address][]         | The identifying address of this account, in base-58. |
+| `inception`       | String - [Timestamp][]       | The UTC timestamp when the address was funded. For genesis accounts, this is the timestamp of ledger 32570. |
+| `ledger_index`    | Number - [Ledger Index][]    | The sequence number of the ledger when the account was created, or 32570 for genesis accounts. |
+| `parent`          | String - [Address][]         | (Omitted for genesis accounts) The address that provided the XRP to fund this address. |
+| `tx_hash`         | String - [Hash][]            | (Omitted for genesis accounts) The identifying hash of the transaction that funded this account. |
+| `initial_balance` | [String - Number][]          | (Omitted for genesis accounts) The amount of XRP that funded this account. |
+| `genesis_balance` | [String - Number][]          | (Genesis accounts only) The amount of XRP this account held as of ledger #32570. |
+| `genesis_index`   | Number - [Sequence Number][] | (Genesis accounts only) The transaction sequence number of the account as of ledger #32570. |
 
 
 ## Exchange Objects
@@ -5251,27 +5138,27 @@ An exchange object represents an actual exchange of currency, which can occur in
 
 A single transaction can cause several exchanges to occur. In this case, the sender of the transaction is the taker for all the exchanges, but each exchange has a different provider, currency pair, or both.
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `base_amount` | Number | The amount of the base currency that was traded. |
-| `counter_amount` | Number | The amount of the counter currency that was traded. |
-| `rate` | Number | The amount of the counter currency acquired per 1 unit of the base currency. |
-| `autobridged_currency` | String - [Currency Code][] | (May be omitted) If the offer was autobridged (XRP order books were used to bridge two non-XRP currencies), this is the other currency from the offer that executed this exchange. |
-| `autobridged_issuer` | String - [Address][] | (May be omitted) If the offer was autobridged (XRP order books were used to bridge two non-XRP currencies), this is the other currency from the offer that executed this exchange. |
-| `base_currency` | String - [Currency Code][] | The base currency. |
-| `base_issuer` | String - [Address][] | (Omitted for XRP) The account that issued the base currency. |
-| `buyer` | String - [Address][] | The account that acquired the base currency. |
-| `client` | String | (May be omitted) If the transaction contains a memo indicating what client application sent it, this is the contents of the memo. |
-| `counter_currency` | String - [Currency Code][] | The counter currency. |
-| `counter_issuer` | String - [Address][] | (Omitted for XRP) The account that issued the counter currency. |
-| `executed_time` | String - [Timestamp][] | The time the exchange occurred. |
-| `ledger_index` | Number - [Ledger Index][] | The sequence number of the ledger that included this transaction. |
-| `offer_sequence` | Number - [Sequence Number][] | The sequence number of the `provider`'s existing offer in the ledger. |
-| `provider` | String - [Address][] | The account that had an existing Offer in the ledger. |
-| `seller` | String - [Address][] | The account that acquired the counter currency. |
-| `taker` | String - [Address][] | The account that sent the transaction which executed this exchange. |
-| `tx_hash` | String - [Hash][] | The identifying hash of the transaction that executed this exchange. (**Note:** This exchange may be one of several executed in a single transaction.) |
-| `tx_type` | String | The type of transaction that executed this exchange, either `Payment` or `OfferCreate`. |
+| Field                  | Value                        | Description          |
+|:-----------------------|:-----------------------------|:---------------------|
+| `base_amount`          | Number                       | The amount of the base currency that was traded. |
+| `counter_amount`       | Number                       | The amount of the counter currency that was traded. |
+| `rate`                 | Number                       | The amount of the counter currency acquired per 1 unit of the base currency. |
+| `autobridged_currency` | String - [Currency Code][]   | (May be omitted) If the offer was autobridged (XRP order books were used to bridge two non-XRP currencies), this is the other currency from the offer that executed this exchange. |
+| `autobridged_issuer`   | String - [Address][]         | (May be omitted) If the offer was autobridged (XRP order books were used to bridge two non-XRP currencies), this is the other currency from the offer that executed this exchange. |
+| `base_currency`        | String - [Currency Code][]   | The base currency.   |
+| `base_issuer`          | String - [Address][]         | (Omitted for XRP) The account that issued the base currency. |
+| `buyer`                | String - [Address][]         | The account that acquired the base currency. |
+| `client`               | String                       | (May be omitted) If the transaction contains a memo indicating what client application sent it, this is the contents of the memo. |
+| `counter_currency`     | String - [Currency Code][]   | The counter currency. |
+| `counter_issuer`       | String - [Address][]         | (Omitted for XRP) The account that issued the counter currency. |
+| `executed_time`        | String - [Timestamp][]       | The time the exchange occurred. |
+| `ledger_index`         | Number - [Ledger Index][]    | The sequence number of the ledger that included this transaction. |
+| `offer_sequence`       | Number - [Sequence Number][] | The sequence number of the `provider`'s existing offer in the ledger. |
+| `provider`             | String - [Address][]         | The account that had an existing Offer in the ledger. |
+| `seller`               | String - [Address][]         | The account that acquired the counter currency. |
+| `taker`                | String - [Address][]         | The account that sent the transaction which executed this exchange. |
+| `tx_hash`              | String - [Hash][]            | The identifying hash of the transaction that executed this exchange. (**Note:** This exchange may be one of several executed in a single transaction.) |
+| `tx_type`              | String                       | The type of transaction that executed this exchange, either `Payment` or `OfferCreate`. |
 
 
 ## Reports Objects
@@ -5279,33 +5166,33 @@ A single transaction can cause several exchanges to occur. In this case, the sen
 
 Reports objects show the activity of a given account over a specific interval of time, typically a day. Reports have the following fields:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `account` | String - [Address][] | The address of the account to which this report pertains. |
-| `date` | String - [Timestamp][] | The start of the interval to which this report pertains. |
-| `high_value_received` | [String - Number][] | Largest amount received in a single transaction, normalized to XRP (as closely as possible). This includes payments and exchanges. |
-| `high_value_sent` | [String - Number][] | The largest amount sent in a single transaction, normalized to XRP (as closely as possible). |
-| `payments` | Array of [Payment Summary Objects][] | (May be omitted) Array with information on each payment sent or received by the account during this interval. |
-| `payments_received` | Number | The number of payments sent to this account. (This only includes payments for which this account was the destination, not payments that only rippled through the account or consumed the account's offers.) |
-| `payments_sent` | Number | The number of payments sent by this account. |
-| `receiving_counterparties` | Array or Number | If account lists requested, an array of addresses that received payments from this account. Otherwise, the number of different accounts that received payments from this account. |
-| `sending_counterparties` | Array or Number |  If account lists requested, an array of addresses that sent payments to this account. Otherwise, the number of different accounts that sent payments to this account. |
-| `total_value` | [String - Number][] | Sum of total value received and sent in payments, normalized to XRP (as closely as possible). |
-| `total_value_received` | [String - Number][] | Sum value of all payments to this account, normalized to XRP (as closely as possible). |
-| `total_value_sent` | [String - Number][] | Sum value of all payments from this account, normalized to XRP (as closely as possible).
+| Field                      | Value                                | Description |
+|:---------------------------|:-------------------------------------|:---------|
+| `account`                  | String - [Address][]                 | The address of the account to which this report pertains. |
+| `date`                     | String - [Timestamp][]               | The start of the interval to which this report pertains. |
+| `high_value_received`      | [String - Number][]                  | Largest amount received in a single transaction, normalized to XRP (as closely as possible). This includes payments and exchanges. |
+| `high_value_sent`          | [String - Number][]                  | The largest amount sent in a single transaction, normalized to XRP (as closely as possible). |
+| `payments`                 | Array of [Payment Summary Objects][] | (May be omitted) Array with information on each payment sent or received by the account during this interval. |
+| `payments_received`        | Number                               | The number of payments sent to this account. (This only includes payments for which this account was the destination, not payments that only rippled through the account or consumed the account's offers.) |
+| `payments_sent`            | Number                               | The number of payments sent by this account. |
+| `receiving_counterparties` | Array or Number                      | If account lists requested, an array of addresses that received payments from this account. Otherwise, the number of different accounts that received payments from this account. |
+| `sending_counterparties`   | Array or Number                      | If account lists requested, an array of addresses that sent payments to this account. Otherwise, the number of different accounts that sent payments to this account. |
+| `total_value`              | [String - Number][]                  | Sum of total value received and sent in payments, normalized to XRP (as closely as possible). |
+| `total_value_received`     | [String - Number][]                  | Sum value of all payments to this account, normalized to XRP (as closely as possible). |
+| `total_value_sent`         | [String - Number][]                  | Sum value of all payments from this account, normalized to XRP (as closely as possible). |
 
 ## Payment Summary Objects
 [Payment Summary Objects]: #payment-summary-objects
 
 A Payment Summary Object contains a reduced amount of information about a single payment from the perspective of either the sender or receiver of that payment.
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `tx_hash` | String - [Hash][] | The identifying hash of the transaction that caused the payment. |
-| `delivered_amount` | [String - Number][] | The amount of the destination `currency` actually received by the destination account. |
-| `currency` | String - [Currency Code][] | The currency delivered to the recipient of the transaction. |
-| `issuer` | String - [Address][] | The gateway issuing the currency, or an empty string for XRP. |
-| `type` | String | Either `sent` or `received`, indicating whether the perspective account is sender or receiver of this transaction. |
+| Field              | Value                      | Description                |
+|:-------------------|:---------------------------|:---------------------------|
+| `tx_hash`          | String - [Hash][]          | The identifying hash of the transaction that caused the payment. |
+| `delivered_amount` | [String - Number][]        | The amount of the destination `currency` actually received by the destination account. |
+| `currency`         | String - [Currency Code][] | The currency delivered to the recipient of the transaction. |
+| `issuer`           | String - [Address][]       | The gateway issuing the currency, or an empty string for XRP. |
+| `type`             | String                     | Either `sent` or `received`, indicating whether the perspective account is sender or receiver of this transaction. |
 
 
 ## Payment Objects
@@ -5315,22 +5202,22 @@ In the Data API, a Payment Object represents an event where one account sent val
 
 Payment objects have the following fields:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `amount` | [String - Number][] | The amount of the destination `currency` that the transaction was instructed to send. In the case of Partial Payments, this is a "maximum" amount. |
-| `delivered_amount` | [String - Number][] | The amount of the destination `currency` actually received by the destination account. |
-| `destination_balance_changes` | Array | Array of [balance change objects][], indicating all changes made to the `destination` account's balances. |
-| `source_balance_changes` | Array | Array of [balance change objects][], indicating all changes to the `source` account's balances (except the XRP transaction cost). |
-| `transaction_cost` | [String - Number][] | The amount of XRP spent by the `source` account on the transaction cost. (Prior to [v2.0.4][], this parameter was called `fee`.) |
-| `destination_tag` | Integer | (May be omitted) A [destination tag](https://developers.ripple.com/become-an-xrp-ledger-gateway.html#source-and-destination-tags) specified in this payment. |
-| `source_tag` | Integer | (May be omitted) A [source tag](https://developers.ripple.com/become-an-xrp-ledger-gateway.html#source-and-destination-tags) specified in this payment. |
-| `currency` | String - [Currency Code][] | The currency that the `destination` account received. |
-| `destination` | String - [Address][] | The account that received the payment. |
-| `executed_time` | String - [Timestamp][] | The time the ledger that included this payment closed. |
-| `ledger_index` | Number - [Ledger Index][] | The sequence number of the ledger that included this payment. |
-| `source` | String - [Address][] | The account that sent the payment. |
-| `source_currency` | String - [Currency Code][] | The currency that the `source` account spent. |
-| `tx_hash` | String - [Hash][] | The identifying hash of the transaction that caused the payment. |
+| Field                         | Value                      | Description     |
+|:------------------------------|:---------------------------|:----------------|
+| `amount`                      | [String - Number][]        | The amount of the destination `currency` that the transaction was instructed to send. In the case of Partial Payments, this is a "maximum" amount. |
+| `delivered_amount`            | [String - Number][]        | The amount of the destination `currency` actually received by the destination account. |
+| `destination_balance_changes` | Array                      | Array of [balance change objects][], indicating all changes made to the `destination` account's balances. |
+| `source_balance_changes`      | Array                      | Array of [balance change objects][], indicating all changes to the `source` account's balances (except the XRP transaction cost). |
+| `transaction_cost`            | [String - Number][]        | The amount of XRP spent by the `source` account on the transaction cost. (Prior to [v2.0.4][], this parameter was called `fee`.) |
+| `destination_tag`             | Integer                    | (May be omitted) A [destination tag](https://developers.ripple.com/become-an-xrp-ledger-gateway.html#source-and-destination-tags) specified in this payment. |
+| `source_tag`                  | Integer                    | (May be omitted) A [source tag](https://developers.ripple.com/become-an-xrp-ledger-gateway.html#source-and-destination-tags) specified in this payment. |
+| `currency`                    | String - [Currency Code][] | The currency that the `destination` account received. |
+| `destination`                 | String - [Address][]       | The account that received the payment. |
+| `executed_time`               | String - [Timestamp][]     | The time the ledger that included this payment closed. |
+| `ledger_index`                | Number - [Ledger Index][]  | The sequence number of the ledger that included this payment. |
+| `source`                      | String - [Address][]       | The account that sent the payment. |
+| `source_currency`             | String - [Currency Code][] | The currency that the `source` account spent. |
+| `tx_hash`                     | String - [Hash][]          | The identifying hash of the transaction that caused the payment. |
 
 
 ## Balance Objects and Balance Change Objects
@@ -5343,11 +5230,11 @@ A single XRP Ledger transaction may cause changes to balances with several count
 
 Balance objects and Balance Change objects have the same format, with the following fields:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `counterparty` | String - [Address][] | The counterparty, or issuer, of the `currency`. In the case of XRP, this is an empty string. |
-| `currency` | String - [Currency Code][] | The currency for which this balance changed. |
-| `value` | [String - Number][] | The amount of the `currency` that the associated account gained or lost. In balance change objects, this value can be positive (for amounts gained) or negative (for amounts lost). In balance objects, this value can be positive (for amounts the counterparty owes the account) or negative (for amounts owed to the counterparty). |
+| Field          | Value                      | Description                    |
+|:---------------|:---------------------------|:-------------------------------|
+| `counterparty` | String - [Address][]       | The counterparty, or issuer, of the `currency`. In the case of XRP, this is an empty string. |
+| `currency`     | String - [Currency Code][] | The currency for which this balance changed. |
+| `value`        | [String - Number][]        | The amount of the `currency` that the associated account gained or lost. In balance change objects, this value can be positive (for amounts gained) or negative (for amounts lost). In balance objects, this value can be positive (for amounts the counterparty owes the account) or negative (for amounts owed to the counterparty). |
 
 
 ## Balance Change Descriptors
@@ -5357,44 +5244,44 @@ Balance Change Descriptors are objects that describe and analyze a single balanc
 
 Balance Change Descriptors have the following fields:
 
-| Field | Value | Description |
-|-------|-------|-------------|
-| `amount_change` | [String - Number][] | The difference in the amount of currency held before and after this change. _(Prior to [v2.0.6][], this field was called `change`.)_ |
-| `final_balance` | [String - Number][] | The balance after the change occurred. |
-| `node_index` | Number (or `null`)| This balance change is represented by the entry at this index of the ModifiedNodes array within the metadata section of the transaction that executed this balance change. **Note:** When the transaction cost is combined with other changes to XRP balance, the transaction cost has a `node_index` of **null** instead. |
-| `tx_index` | Number | The transaction that executed this balance change is at this index in the array of transactions for the ledger that included it. |
-| `change_type` | String | One of several [](#change-types) describing what caused this balance change to occur. |
-| `currency` | String - [Currency Code][] | The change affected this currency. |
-| `executed_time` | String - [Timestamp][] | The time the change occurred. (This is based on the close time of the ledger that included the transaction that executed the change. |
-| `counterparty` | String - [Address][] | (Omitted for XRP) The `currency` is held in a trust line to or from this account. _(Prior to [v2.0.6][], this field was called `issuer`.)_ |
-| `ledger_index` | Number - [Ledger Index][] | The sequence number of the ledger that included the transaction that executed this balance change. |
-| `tx_hash` | String - [Hash][] | The identifying hash of the transaction that executed this balance change. |
+| Field           | Value                      | Description                   |
+|:----------------|:---------------------------|:------------------------------|
+| `amount_change` | [String - Number][]        | The difference in the amount of currency held before and after this change. _(Prior to [v2.0.6][], this field was called `change`.)_ |
+| `final_balance` | [String - Number][]        | The balance after the change occurred. |
+| `node_index`    | Number (or `null`)         | This balance change is represented by the entry at this index of the ModifiedNodes array within the metadata section of the transaction that executed this balance change. **Note:** When the transaction cost is combined with other changes to XRP balance, the transaction cost has a `node_index` of **null** instead. |
+| `tx_index`      | Number                     | The transaction that executed this balance change is at this index in the array of transactions for the ledger that included it. |
+| `change_type`   | String                     | One of several [](#change-types) describing what caused this balance change to occur. |
+| `currency`      | String - [Currency Code][] | The change affected this currency. |
+| `executed_time` | String - [Timestamp][]     | The time the change occurred. (This is based on the close time of the ledger that included the transaction that executed the change. |
+| `counterparty`  | String - [Address][]       | (Omitted for XRP) The `currency` is held in a trust line to or from this account. _(Prior to [v2.0.6][], this field was called `issuer`.)_ |
+| `ledger_index`  | Number - [Ledger Index][]  | The sequence number of the ledger that included the transaction that executed this balance change. |
+| `tx_hash`       | String - [Hash][]          | The identifying hash of the transaction that executed this balance change. |
 
 ### Change Types
 
 The following values are valid for the `change_type` field of a Balance Change Descriptor:
 
-| Value | Meaning |
-|-------|---------|
-| `transaction_cost` | This balance change reflects XRP that was destroyed to relay a transaction. _(Prior to [v2.0.4][], this was `network fee` instead.)_ |
+| Value                 | Meaning                                              |
+|:----------------------|:-----------------------------------------------------|
+| `transaction_cost`    | This balance change reflects XRP that was destroyed to relay a transaction. _(Prior to [v2.0.4][], this was `network fee` instead.)_ |
 | `payment_destination` | This balance change reflects currency that was received from a payment. |
-| `payment_source` | This balance change reflects currency that was spent in a payment. |
-| `exchange` | This balance change reflects currency that was traded for other currency, or the same currency from a different issuer. This can occur in the middle of payment execution as well as from offers. |
+| `payment_source`      | This balance change reflects currency that was spent in a payment. |
+| `exchange`            | This balance change reflects currency that was traded for other currency, or the same currency from a different issuer. This can occur in the middle of payment execution as well as from offers. |
 
 ## Volume Objects
 [Volume Objects]: #volume-objects
 
 Volume objects represent the total volumes of money moved, in either payments or exchanges, during a given period.
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `components` | Array of Objects | The data that was used to assemble this total. For payment volume, each object represents payments in a particular currency and issuer. For exchange volume, each object represents a market between two currencies. |
-| `count` | Number | The total number of exchanges in this period. |
-| `end_time` | String - [Timestamp][] | The end time of this interval. |
-| `exchange` | Object | Indicates the display currency used, as with fields `currency` and (except for XRP) `issuer`. All amounts are normalized by first converting to XRP, and then to the display currency specified in the request. |
-| `exchange_rate` | Number | The exchange rate to the displayed currency from XRP.
-| `start_time` | String - [Timestamp][] | The start of this period. |
-| `total` | Number | Total volume of all recorded exchanges in the period. |
+| Field           | Value                  | Description                       |
+|:----------------|:-----------------------|:----------------------------------|
+| `components`    | Array of Objects       | The data that was used to assemble this total. For payment volume, each object represents payments in a particular currency and issuer. For exchange volume, each object represents a market between two currencies. |
+| `count`         | Number                 | The total number of exchanges in this period. |
+| `end_time`      | String - [Timestamp][] | The end time of this interval.    |
+| `exchange`      | Object                 | Indicates the display currency used, as with fields `currency` and (except for XRP) `issuer`. All amounts are normalized by first converting to XRP, and then to the display currency specified in the request. |
+| `exchange_rate` | Number                 | The exchange rate to the displayed currency from XRP. |
+| `start_time`    | String - [Timestamp][] | The start of this period.         |
+| `total`         | Number                 | Total volume of all recorded exchanges in the period. |
 
 
 ## Server Objects
@@ -5405,30 +5292,30 @@ A "Server Object" describes one `rippled` server in the XRP Ledger peer-to-peer 
 
 Server objects have the following fields, with some only appearing if the request specified a verbose response:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
-| `node_public_key` | String - Base-58 [Public Key][] | The public key used by this server to sign its peer-to-peer communications, not including validations. |
-| `version` | String | The `rippled` version of this server, when it was last asked. |
-| `uptime` | Integer | Number of seconds this server has been connected to the network. |
-| `ip` | String | (May be omitted) IP address of the node (may be omitted) |
-| `port` | Integer | (May be omitted) Port where this server speaks the [`rippled` Peer Protocol](https://developers.ripple.com/peer-protocol.html). |
-| `inbound_count` | Integer | (May be omitted) Number of inbound peer-to-peer connections to this server. |
-| `inbound_added` | String | (May be omitted) Number of new inbound peer-to-peer connections since the last measurement.  |
-| `inbound_dropped` | String | (May be omitted) Number of inbound peer-to-peer connections dropped since the last measurement. |
-| `outbound_count` | Integer | (May be omitted) Number of outbound peer-to-peer connections to this server. |
-| `outbound_added` | String | (May be omitted) Number of new outbound peer-to-peer connections since the last measurement. |
-| `outbound_dropped` | String | (May be omitted) Number of outbound peer-to-peer connections dropped since the last measurement. |
-| `city` | String | (Verbose only) The city where this server is located, according to IP geolocation. |
-| `region` | String | (Verbose only) The region where this server is located, according to IP geolocation. |
-| `country` | String | (Verbose only) The country where this server is located, according to IP geolocation. |
-| `region_code` | String | (Verbose only) The ISO code for the region where this server is located, according to IP geolocation. |
-| `country_code` | String | (Verbose only) The ISO code for the country where this server is located, according to IP geolocation. |
-| `postal_code` | String | (Verbose only) The postal code where this server is located, according to IP geolocation. |
-| `timezone` | String | (Verbose only) The ISO timezone where this server is located, according to IP geolocation. |
-| `lat` | String | (Verbose only) The latitude where this server is located, according to IP geolocation. |
-| `long` | String | (Verbose only) The longitude where this server is located, according to IP geolocation. |
-| `isp` | String | (Verbose only) The Internet Service Provider hosting this server's public IP address. |
-| `org` | String | (Verbose only) The organization that owns this server's public IP address. |
+| Field              | Value                           | Description           |
+|:-------------------|:--------------------------------|:----------------------|
+| `node_public_key`  | String - Base-58 [Public Key][] | The public key used by this server to sign its peer-to-peer communications, not including validations. |
+| `version`          | String                          | The `rippled` version of this server, when it was last asked. |
+| `uptime`           | Integer                         | Number of seconds this server has been connected to the network. |
+| `ip`               | String                          | (May be omitted) IP address of the node (may be omitted). |
+| `port`             | Integer                         | (May be omitted) Port where this server speaks the [`rippled` Peer Protocol](https://developers.ripple.com/peer-protocol.html). |
+| `inbound_count`    | Integer                         | (May be omitted) Number of inbound peer-to-peer connections to this server. |
+| `inbound_added`    | String                          | (May be omitted) Number of new inbound peer-to-peer connections since the last measurement. |
+| `inbound_dropped`  | String                          | (May be omitted) Number of inbound peer-to-peer connections dropped since the last measurement. |
+| `outbound_count`   | Integer                         | (May be omitted) Number of outbound peer-to-peer connections to this server. |
+| `outbound_added`   | String                          | (May be omitted) Number of new outbound peer-to-peer connections since the last measurement. |
+| `outbound_dropped` | String                          | (May be omitted) Number of outbound peer-to-peer connections dropped since the last measurement. |
+| `city`             | String                          | (Verbose only) The city where this server is located, according to IP geolocation. |
+| `region`           | String                          | (Verbose only) The region where this server is located, according to IP geolocation. |
+| `country`          | String                          | (Verbose only) The country where this server is located, according to IP geolocation. |
+| `region_code`      | String                          | (Verbose only) The ISO code for the region where this server is located, according to IP geolocation. |
+| `country_code`     | String                          | (Verbose only) The ISO code for the country where this server is located, according to IP geolocation. |
+| `postal_code`      | String                          | (Verbose only) The postal code where this server is located, according to IP geolocation. |
+| `timezone`         | String                          | (Verbose only) The ISO timezone where this server is located, according to IP geolocation. |
+| `lat`              | String                          | (Verbose only) The latitude where this server is located, according to IP geolocation. |
+| `long`             | String                          | (Verbose only) The longitude where this server is located, according to IP geolocation. |
+| `isp`              | String                          | (Verbose only) The Internet Service Provider hosting this server's public IP address. |
+| `org`              | String                          | (Verbose only) The organization that owns this server's public IP address. |
 
 
 ## Link Objects
@@ -5437,8 +5324,8 @@ Server objects have the following fields, with some only appearing if the reques
 
 A Link Object represents a peer-to-peer network connection between two `rippled` servers. It has the following fields:
 
-| Field  | Value | Description |
-|--------|-------|-------------|
+| Field    | Value                           | Description                     |
+|:---------|:--------------------------------|:--------------------------------|
 | `source` | String - Base-58 [Public Key][] | The node public key of the `rippled` making the outgoing connection. |
 | `target` | String - Base-58 [Public Key][] | The node public key of the `rippled` receiving the incoming connection. |
 
@@ -5453,15 +5340,15 @@ A Validation Object represents one vote from a validator to mark a ledger versio
 
 A Validation Object has the following fields:
 
-| Field  | Value  | Description |
-|--------|--------|-------------|
-| `count`  | Integer | (May be omitted) The number of `rippled` servers that reported seeing this validation. Not available for old data. |
-| `ledger_hash` | String - [Hash][]  | The hash of the ledger version this validation vote applies to. |
-| `reporter_public_key` | String - Base-58 [Public Key][] | The public key of the `rippled` server that first reported this validation, in base-58. |
+| Field                   | Value                           | Description      |
+|:------------------------|:--------------------------------|:-----------------|
+| `count`                 | Integer                         | (May be omitted) The number of `rippled` servers that reported seeing this validation. Not available for old data. |
+| `ledger_hash`           | String - [Hash][]               | The hash of the ledger version this validation vote applies to. |
+| `reporter_public_key`   | String - Base-58 [Public Key][] | The public key of the `rippled` server that first reported this validation, in base-58. |
 | `validation_public_key` | String - Base-58 [Public Key][] | The public key of the validator used to sign this validation, in base-58. |
-| `signature` | String | The validator's signature of the validation details, in hexadecimal. |
-| `first_datetime` | String - [Timestamp][] | Date and time of the first report of this validation. |
-| `last_datetime` | String - [Timestamp][] | Date and time of the last report of this validation. |
+| `signature`             | String                          | The validator's signature of the validation details, in hexadecimal. |
+| `first_datetime`        | String - [Timestamp][]          | Date and time of the first report of this validation. |
+| `last_datetime`         | String - [Timestamp][]          | Date and time of the last report of this validation. |
 
 
 


### PR DESCRIPTION
- Remove the "Get Capitalization" method docs to match the code
- Sync up some minor differences like mentions of removed fields
- Remove link from ToC to removed "Get Issued Value" method
- Match whitespace in the dev portal version ( https://github.com/ripple/ripple-dev-portal/blob/master/content/references/data-api.md )
- Match URL templating convention ([RFC6570](https://tools.ietf.org/html/rfc6570)) to dev portal