### PR TITLE
accountTransactions - Add missing tx types & err codes

### DIFF
--- a/api/routes/accountTransactions.js
+++ b/api/routes/accountTransactions.js
@@ -6,11 +6,22 @@ var hbase = require('../../lib/hbase')
 var intMatch = /^\d+$/;
 
 var txTypes = [
-  'Payment',
-  'OfferCreate',
-  'OfferCancel',
   'AccountSet',
+  'CheckCancel',
+  'CheckCash',
+  'CheckCreate',
+  'DepositPreauth',
+  'EscrowCancel',
+  'EscrowCreate',
+  'EscrowFinish',
+  'OfferCancel',
+  'OfferCreate',
+  'Payment',
+  'PaymentChannelClaim',
+  'PaymentChannelCreate',
+  'PaymentChannelFund',
   'SetRegularKey',
+  'SignerListSet',
   'TrustSet',
   'EnableAmendment',
   'SetFee'
@@ -48,7 +59,12 @@ var txResults = [
   'tecNEED_MASTER_KEY',
   'tecDST_TAG_NEEDED',
   'tecINTERNAL',
-  'tecOVERSIZE'
+  'tecOVERSIZE',
+  'tecCRYPTOCONDITION_ERROR',
+  'tecINVARIANT_FAILED',
+  'tecEXPIRED',
+  'tecDUPLICATE',
+  'tecKILLED'
 ];
 
 var accountTransactions = function (req, res) {


### PR DESCRIPTION
Was confused why I couldn't get EscrowCreate transactions for my account. Looked at the source. Figured out why. This should (hopefully) fix.

Not sure if any backend work is necessary to support this or if the ingestor already handles the new tx types and codes appropriately.